### PR TITLE
Phase 1.7: 자동 알림 시스템

### DIFF
--- a/.claude/docs/pdca-status.json
+++ b/.claude/docs/pdca-status.json
@@ -1,9 +1,9 @@
 {
   "overview": {
     "total": 25,
-    "completed": 8,
+    "completed": 9,
     "phases": {
-      "phase-1": { "completed": 8, "total": 12, "progress": "66.7%" },
+      "phase-1": { "completed": 9, "total": 12, "progress": "75%" },
       "phase-2": { "completed": 0, "total": 2, "progress": "0%" },
       "phase-3": { "completed": 0, "total": 5, "progress": "0%" },
       "phase-4": { "completed": 0, "total": 6, "progress": "0%" }
@@ -67,7 +67,7 @@
       { "features": "phase-1-4-notification-store", "phase": "archived", "matchRate": 100.0, "description": "users/{userId}/notifications/settings Firestore 저장소 구현 + AlarmSubscription 타입 단일화 (common/types로 통합, AlertModeSelectAction enum → AlertMode as const 객체 전환)", "startedAt": "2026-05-13", "completedAt": "2026-05-24", "documents": { "plan": "docs/archive/phase-1-4/01-plan.md", "design": "docs/archive/phase-1-4/02-design.md", "analysis": "docs/archive/phase-1-4/03-analysis.md", "report": "docs/archive/phase-1-4/04-report.md" } },
       { "features": "phase-1-5-notification-settings-ui", "phase": "archived", "matchRate": 98.3, "description": "/alarm-subscribe 슬래시 커맨드 UI 완성 — 모드(전체/선택) 전환, 지역 편집(SelectMenu), 알림 켜기/끄기 토글, U1+U3+U5 안정화(클릭 즉시 disabled + '⏳ 적용 중…' 라벨 + Firestore round-trip 3→2), 전역 에러 핸들러 dev/prod 분기 + 신규 헬퍼 disableMessageComponents", "startedAt": "2026-05-25", "completedAt": "2026-06-08", "documents": { "plan": "docs/archive/phase-1-5/01-plan.md", "design": "docs/archive/phase-1-5/02-design.md", "analysis": "docs/archive/phase-1-5/03-analysis.md", "report": "docs/archive/phase-1-5/04-report.md" } },
       { "features": "phase-1-6-recruit-request-enhancement", "phase": "archived", "matchRate": 100.0, "documents": { "plan": "docs/archive/phase-1-6/01-plan.md", "design": "docs/archive/phase-1-6/02-design.md", "analysis": "docs/archive/phase-1-6/03-analysis.md", "report": "docs/archive/phase-1-6/04-report.md" } },
-      { "features": "phase-1-7-auto-notification-system", "phase": null, "matchRate": null, "documents": {} },
+      { "features": "phase-1-7-auto-notification-system", "phase": "archived", "matchRate": 100.0, "description": "RECRUIT_NEW 구독 → 활성 구독자 조회 → 모드/지역 필터(filterByMode/filterByRegion) → 구독자별 NOTIFICATION_SEND 발행 (이벤트 경계까지). 필터를 common/utils로 배치(services→features 금지 준수), 잡셋=addedJobs+updatedJobs. 실제 DM 발송은 1.8, startup wiring은 1.9 위임", "startedAt": "2026-06-08", "completedAt": "2026-06-09", "documents": { "plan": "docs/archive/phase-1-7/01-plan.md", "design": "docs/archive/phase-1-7/02-design.md", "analysis": "docs/archive/phase-1-7/03-analysis.md", "report": "docs/archive/phase-1-7/04-report.md" } },
       { "features": "phase-1-8-discord-dm-utility", "phase": null, "matchRate": null, "documents": {} },
       { "features": "phase-1-9-scheduler-reactivation", "phase": null, "matchRate": null, "documents": {} },
       { "features": "phase-1-10-proxy-integration", "phase": null, "matchRate": null, "documents": {} }

--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ user-memo.md
 # Daily TODO tracker (Claude Code)
 .claude/docs/todo.md
 
-# Agent memory (Claude Code) — 루트·중첩(functions/ 등) 모두 무시
+# Agent memory (Claude Code)
 **/.claude/agent-memory/
 
 # Local verification scripts (not part of deploy)

--- a/.gitignore
+++ b/.gitignore
@@ -83,8 +83,8 @@ user-memo.md
 # Daily TODO tracker (Claude Code)
 .claude/docs/todo.md
 
-# Agent memory (Claude Code)
-.claude/agent-memory/
+# Agent memory (Claude Code) — 루트·중첩(functions/ 등) 모두 무시
+**/.claude/agent-memory/
 
 # Local verification scripts (not part of deploy)
 functions/scripts/

--- a/docs/archive/phase-1-7/01-plan.md
+++ b/docs/archive/phase-1-7/01-plan.md
@@ -1,0 +1,119 @@
+# Phase 1.7: 자동 알림 시스템 (auto-notification-system)
+
+**상태**: 🔄 진행 중
+**우선순위**: P0
+**의존성**: phase-1-3-recruitcacheservice-event-integration (✅ completed), phase-1-4-notification-store (✅ archived)
+
+---
+
+## 개요
+
+### 배경
+크롤링이 새 공고를 감지하면 `RECRUIT_NEW` 이벤트가 발행된다(Phase 1.3 완료). 구독자별 알림 설정 저장소도 구축됐다(Phase 1.4 완료). 그러나 둘을 잇는 **소비 계층이 없어**, 새 공고가 감지돼도 구독자에게 알림이 가지 않는다. Phase 1.7은 이 공백을 메우는 핵심 기능이다.
+
+### 목표
+`RECRUIT_NEW` 이벤트를 구독하여, 활성 구독자를 조회하고, 각 구독자의 알림 모드(전체/선택)와 지역으로 공고를 필터링한 뒤, 구독자별 `NOTIFICATION_SEND` 이벤트를 발행한다.
+
+### 범위
+
+| 포함 | 제외 |
+|------|------|
+| `RECRUIT_NEW` 구독 → 활성 구독자 조회 → 모드/지역 필터 → `NOTIFICATION_SEND` 발행 | 실제 DM 발송 (Phase 1.8 영역) |
+| `RecruitFilter` (모드/지역 필터 순수 함수) | `registerAllEventHandlers()` startup 호출 wiring (Phase 1.9 영역) |
+| `registerEventHandlers.ts` 알림 핸들러 등록 활성화 | Phase 1.3 try-catch → errorHandler 에러 고도화 (소비자 부재 — Phase 2.1과 재검토) |
+
+> **설계 경계 = 이벤트 경계.** Phase 1.7은 구독자별 필터링 후 `NOTIFICATION_SEND` 이벤트 발행까지만 담당한다. 실제 DM 전송은 Phase 1.8 핸들러가 수행하므로, **1.7 단독으로는 DM이 실제 전송되지 않는다**(의도된 설계).
+
+---
+
+## 요구사항
+
+### 기능 요구사항
+1. `EventBus`에서 `EventType.RECRUIT_NEW`(`"recruit:new"`)를 구독한다. 페이로드 `RecruitNewEvent`는 flat 구조(`{ timestamp, source?, addedJobs, updatedJobs, deletedIds }`)다.
+2. `SubscriptionStore.getAllActiveSubscribers()`로 `enabled === true` 구독자(`AlarmSubscription[]`)를 조회한다.
+3. 각 구독자에 대해 알림 모드별 필터링한다:
+   - `AlertMode.ALL` → 새 공고 전체 대상
+   - `AlertMode.SELECTED` → 구독자 `regions: CityEn[]`에 매칭되는 공고만 (`CityEn` → `toKorean` 변환 후 `value.title.includes(koreanName)`, 기존 `filterListByCity` 코어 재사용)
+4. 매칭 공고가 1개 이상인 구독자에 대해 `emitEvent<NotificationSendEvent>(NOTIFICATION_SEND, { userId, jobs, settings })`를 발행한다.
+5. `registerEventHandlers.ts`에서 알림 핸들러 등록 placeholder를 활성화한다. (`registerAllEventHandlers()` 실제 호출은 Phase 1.9에 위임)
+
+### 비기능 요구사항
+- **성능**: 구독자 수 × 공고 수 선형 필터링. 구독자별 발행은 동기 루프(소량 가정), 대량화는 후속 Phase에서 검토.
+- **호환성**: 기존 `RECRUIT_NEW` 발행부(recruitCacheService) 변경 없음. `NOTIFICATION_SEND` 타입은 기정의된 것 재사용.
+- **에러 처리**: 핸들러 내부는 try-catch로 감싸 emitter로 재throw 금지(EventBus 안정성). 알림 잡셋 기본값은 `addedJobs`(신규 공고). `updatedJobs` 포함 여부는 design 단계에서 확정(스팸 방지 위해 기본 제외 권장).
+
+---
+
+## 기술 스택 (프로젝트 고정)
+
+| 항목 | 기술 |
+|------|------|
+| Runtime | Firebase Functions (Node.js) |
+| Language | TypeScript (strict mode) |
+| Database | Firestore |
+| Messaging | discord.js |
+| Event System | EventBus (Singleton) |
+| Error Handling | SystemError + errorHandler |
+| Logging | SystemLogger |
+
+---
+
+## 구현 전략
+
+### 접근 방식
+이벤트 구동 소비자 패턴. `NotificationEventHandler`가 `RECRUIT_NEW`를 구독 → `notificationService.notifyNewRecruits(payload)` 호출 → 서비스가 구독자 조회·필터·발행을 오케스트레이션. 필터 로직은 순수 함수(`RecruitFilter`)로 분리해 테스트 가능성과 DRY 확보(`filterListByCity` 재사용).
+
+흐름:
+```
+RECRUIT_NEW 수신
+  → getAllActiveSubscribers()
+  → 각 구독자:
+       ALL      → 전체 addedJobs
+       SELECTED → filterByRegion(addedJobs, regions)
+  → 매칭 잡 ≥ 1 → emitEvent<NotificationSendEvent>(NOTIFICATION_SEND, { userId, jobs, settings })
+```
+
+### 영향 받는 파일 (do 단계 산출물 예정)
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `functions/src/services/notificationService.ts` | 신규 | `notifyNewRecruits(payload: RecruitNewEvent)`: 구독자 조회 → 필터 → 구독자별 `NOTIFICATION_SEND` 발행. 핸들러 try-catch로 재throw 금지 |
+| `functions/src/features/notification/filters/RecruitFilter.ts` | 신규 | `filterByMode(jobs, mode)`, `filterByRegion(jobs: Job[], regions: CityEn[])` — `filterListByCity` 코어 재사용, `toKorean` 변환 후 `value.title.includes()` |
+| `functions/src/events/bus/handlers/NotificationEventHandler.ts` | 신규 | `registerNotificationHandlers()`: `eventBus.onEvent<RecruitNewEvent>(RECRUIT_NEW, ...)` |
+| `functions/src/events/bus/utils/registerEventHandlers.ts` | 수정 | `registerNotificationHandlers()` 호출 주석 해제(등록만, startup 호출은 1.9) |
+
+### 위임 계획 (CTO Lead 게이트 결과)
+| 영역 | 위임 대상 | 근거 | 예상 산출물 |
+|------|----------|------|------------|
+| 서비스 오케스트레이션 + 이벤트 핸들러 등록 | **Integration Lead** | RECRUIT_NEW → 구독자 조회 → NOTIFICATION_SEND 의 서비스 간 연동·이벤트 흐름 조율이 핵심 | `notificationService.ts`, `NotificationEventHandler.ts`, `registerEventHandlers.ts` 수정 |
+| 필터 순수 로직 | **Backend Expert** (Integration Lead 위임) | 모드/지역 필터는 데이터 변환 순수 함수 — `filterListByCity` 재사용 + `CityEn→한글` 매칭 | `RecruitFilter.ts` |
+
+> Discord UI 없음(이벤트 경계까지만) → Discord Agent 미관여. 실제 DM 발송 핸들러는 Phase 1.8.
+
+### 의존성 분석
+- **선행(충족)**: Phase 1.3(`RECRUIT_NEW` 발행), Phase 1.4(`SubscriptionStore`, `AlarmSubscription` 타입).
+- **후속**: Phase 1.8(`NOTIFICATION_SEND` 소비 → 실제 DM 발송), Phase 1.9(`registerAllEventHandlers()` startup wiring → E2E 활성화).
+
+---
+
+## 성공 기준
+
+- [ ] `docs/phase-1-7/01-plan.md` 템플릿 구조 준수 + 결정사항(이벤트 경계·제외 항목·1.8/1.9 위임) 반영
+- [ ] feature 브랜치 `feature/phase-1.7-auto-notification-system` 생성
+- [ ] pdca-memory.json / pdca-status.json 갱신 (phase="plan")
+- [ ] TypeScript 컴파일 성공 (do 단계 검증)
+- [ ] 기존 `RECRUIT_NEW` 발행부 정상 동작 확인 (do 단계 검증)
+
+---
+
+## 리스크 및 고려사항
+
+| 리스크 | 영향도 | 대응 방안 |
+|--------|--------|----------|
+| `RecruitData`에 구조화된 region 필드 없음 — 지역이 `title` 한글 부분문자열뿐 → 오탐/누락 가능 | 중 | 기존 `filterListByCity` 동일 정책 유지, design에서 엣지케이스(복수 지역·동음 지명) 검토 |
+| 1.7 단독 런타임 검증 불가 (1.8 DM sender, 1.9 startup wiring 미완) | 중 | 정적 검증(타입·핸들러 등록) 위주, E2E는 1.9 통합 시점으로 명시(알려진 갭) |
+| CLAUDE.md 예시 stale (`payload.data.*`, `getDiscordClient`, `NOTIFICATION_FAILED`) | 저 | 코드 SoT(`events/bus/types.ts`) 기준으로만 구현 |
+
+---
+
+*작성일: 2026-06-08*
+*시드: .claude/phases/phase-1-core.md*

--- a/docs/archive/phase-1-7/02-design.md
+++ b/docs/archive/phase-1-7/02-design.md
@@ -1,0 +1,253 @@
+# Phase 1.7 설계서: 자동 알림 시스템 (auto-notification-system)
+
+**상태**: 🔄 진행 중
+**기반 문서**: `docs/phase-1-7/01-plan.md`
+
+---
+
+## 1. 아키텍처 설계
+
+### 1.1 레이어 매핑
+
+| 프로젝트 레이어 | 변경 내용 |
+|----------------|----------|
+| Routes (`functions/src/routes/`) | 변경 없음 |
+| Services (`functions/src/services/`) | **신규** `notificationService.ts` — `RecruitNewEvent` 수신 → 구독자 조회 → 필터 → 구독자별 `NOTIFICATION_SEND` 발행 오케스트레이션 |
+| EventBus (`functions/src/events/bus/`) | **신규** `handlers/NotificationEventHandler.ts` — `RECRUIT_NEW` 구독 / **수정** `utils/registerEventHandlers.ts` — 핸들러 등록 활성화(등록만, startup 호출은 1.9) |
+| Common Utils (`functions/src/common/`) | **신규** `utils/recruitFilter.ts` — `filterByMode`/`filterByRegion` 순수 함수 (`filterListByCity` 정책 재사용) |
+| Types (`functions/src/common/types/`) | 변경 없음 (`Job`/`AlarmSubscription`/`AlertMode`, 이벤트 페이로드 모두 기정의분 재사용) |
+
+> **레이어 의존 방향**: `handler(events) → service(services) → { providers, eventBus, common }`.
+> `services → features` 의존 금지 규칙(`services/CLAUDE.md`)을 지키기 위해 필터를 `features/`가 아닌
+> `common/utils/`에 배치한다(plan 원안 경로 교정 — SoT 우선순위상 CLAUDE.md > plan).
+
+### 1.2 컴포넌트 다이어그램
+
+```
+[recruitCacheService]  --emit(RECRUIT_NEW)-->  [EventBus]
+                                                   │
+                                                   ▼
+                              [NotificationEventHandler]  (events/bus/handlers)
+                                  │  try-catch (재throw 금지)
+                                  ▼
+                  [notificationService.notifyNewRecruits(payload)]  (services)
+                       │  getAllActiveSubscribers()  ──▶ [SubscriptionStore]   (providers)
+                       │  filterByMode(jobs, sub)     ──▶ [recruitFilter]       (common/utils)
+                       ▼
+              구독자별 emitEvent<NotificationSendEvent>(NOTIFICATION_SEND)
+                                  │
+                                  ▼
+                              [EventBus]  ──▶ [Phase 1.8 DM sender 가 소비]
+```
+
+> **설계 경계 = 이벤트 경계.** Phase 1.7은 `NOTIFICATION_SEND` 발행까지만 담당한다.
+> 실제 DM 전송(1.8)과 `registerAllEventHandlers()` startup 호출(1.9)은 범위 밖이므로
+> **1.7 단독으로는 DM이 실제 전송되지 않는다**(의도된 설계).
+
+---
+
+## 2. 상세 설계
+
+### 2.1 RecruitFilter (모드/지역 필터 순수 함수)
+
+**파일**: `functions/src/common/utils/recruitFilter.ts` (신규)
+
+**인터페이스/타입 정의**:
+```typescript
+import type { Job } from "@/common/types/job.d";
+import type { AlarmSubscription, CityEn } from "@/common/types";
+import { AlertMode } from "@/common/types";
+import { toKorean } from "@/common/utils/cityName";
+
+export function filterByRegion(jobs: Job[], regions: CityEn[]): Job[];
+export function filterByMode(jobs: Job[], subscription: AlarmSubscription): Job[];
+```
+
+**핵심 로직**:
+```typescript
+/**
+ * 지역 필터 (Pure Function)
+ *
+ * `filterListByCity`(common/utils/getCityFilteredList.ts)와 동일한
+ * `title.includes(한글지명)` 정책을 Job[]·복수 지역으로 확장한 어댑터.
+ * 정책 출처를 본 JSDoc에 명시하여 드리프트를 방지한다.
+ */
+export function filterByRegion(jobs: Job[], regions: CityEn[]): Job[] {
+  if (regions.length === 0) return [];
+  const koreanNames = regions
+    .map((r) => toKorean(r))
+    .filter((n): n is string => Boolean(n));
+  return jobs.filter((job) =>
+    koreanNames.some((ko) => job.value.title.includes(ko))
+  );
+}
+
+/** 모드 필터: ALL → 전체, SELECTED → 지역 매칭만 */
+export function filterByMode(jobs: Job[], subscription: AlarmSubscription): Job[] {
+  return subscription.alertMode === AlertMode.ALL
+    ? jobs
+    : filterByRegion(jobs, subscription.regions);
+}
+```
+
+**설계 결정 (DRY)**:
+- `filterListByCity(list: RecruitData[], city?)`는 `RecruitData[]`·단일 city 시그니처라 `Job[]`에 직접 적용 시 `Job.id` 손실 + 복수 지역 처리 불가. 따라서 동일 정책을 `Job[]`·복수 지역에 맞춘 **얇은 어댑터**로 분리하고, 정책 출처를 JSDoc에 명시한다.
+- 지역 매칭은 `Job.value.title.includes(toKorean(region))` — `RecruitData`에 구조화된 region 필드가 없어 title 부분문자열 정책 유지(기존과 동일, 알려진 한계).
+
+**에러 처리**: 순수 함수 — 예외 없음. 빈 지역(`regions: []`)은 빈 배열 반환(매칭 0건).
+
+### 2.2 NotificationService (오케스트레이션)
+
+**파일**: `functions/src/services/notificationService.ts` (신규)
+
+**핵심 로직**:
+```typescript
+import "@/common/utils/systemLogger"; // globalLogger 전역 등록
+import { SubscriptionStore } from "@/providers/firebase/store/subscription";
+import { eventBus, EventType } from "@/events/bus";
+import type { RecruitNewEvent, NotificationSendEvent } from "@/events/bus";
+import { filterByMode } from "@/common/utils/recruitFilter";
+
+export class NotificationService {
+  private readonly subscriptionStore = new SubscriptionStore();
+
+  /**
+   * RECRUIT_NEW 수신 → 활성 구독자별 모드/지역 필터 → NOTIFICATION_SEND 발행.
+   * 실제 DM 발송은 Phase 1.8 핸들러가 NOTIFICATION_SEND를 소비하여 수행.
+   */
+  async notifyNewRecruits(payload: RecruitNewEvent): Promise<void> {
+    const targetJobs = [...payload.addedJobs, ...payload.updatedJobs];
+    if (targetJobs.length === 0) return;
+
+    const subscribers = await this.subscriptionStore.getAllActiveSubscribers();
+    for (const sub of subscribers) {
+      const matched = filterByMode(targetJobs, sub);
+      if (matched.length === 0) continue;
+
+      eventBus.emitEvent<NotificationSendEvent>(EventType.NOTIFICATION_SEND, {
+        timestamp: Date.now(),
+        source: "NotificationService",
+        userId: sub.userId,
+        jobs: matched,
+        settings: sub,
+      });
+    }
+  }
+}
+
+export const notificationService = new NotificationService();
+```
+
+**설계 결정**:
+- **잡셋 = `addedJobs + updatedJobs` 합집합** (사용자 확정). 신규 공고뿐 아니라 변경 공고도 알림 대상.
+- 생성자에서 리스너 등록 **안 함** — 등록은 핸들러(§2.3)로 분리(테스트 가능성·관심사 분리). 싱글톤 `notificationService` export.
+- 구독자별 emit은 동기 루프(소량 가정). 대량화는 후속 Phase 검토(plan 비기능 요구사항).
+
+**에러 처리**: `getAllActiveSubscribers()` 실패 등은 핸들러 try-catch(§2.3)가 흡수한다. `emitEvent`는 동기 호출이라 개별 구독자 발행 실패가 루프를 중단시키지 않는다.
+
+### 2.3 NotificationEventHandler (이벤트 구독)
+
+**파일**: `functions/src/events/bus/handlers/NotificationEventHandler.ts` (신규)
+
+**핵심 로직**:
+```typescript
+import "@/common/utils/systemLogger";
+import { eventBus, EventType } from "@/events/bus";
+import type { RecruitNewEvent } from "@/events/bus";
+import { notificationService } from "@/services/notificationService";
+
+/** RECRUIT_NEW → notificationService.notifyNewRecruits 연결 */
+export function registerNotificationHandlers(): void {
+  eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, async (payload) => {
+    try {
+      await notificationService.notifyNewRecruits(payload);
+    } catch (error) {
+      globalLogger.error("알림 핸들러 처리 실패", error as Error, {
+        event: EventType.RECRUIT_NEW,
+        source: "NotificationEventHandler",
+      });
+    }
+  });
+}
+```
+
+**에러 처리**: 핸들러 내부 try-catch로 EventBus 안정성 확보(emitter로 재throw 금지) — `recruitCacheService`의 발행부 try-catch 패턴과 대칭.
+
+### 2.4 registerEventHandlers (등록 활성화)
+
+**파일**: `functions/src/events/bus/utils/registerEventHandlers.ts` (수정)
+
+**변경 내용**:
+```typescript
+// 상단 import 추가
+import { registerNotificationHandlers } from "../handlers/NotificationEventHandler";
+
+// registerAllEventHandlers() 본문
+// Phase 1.7: NotificationService 핸들러
+registerNotificationHandlers();   // 주석 해제 (기존: // registerNotificationHandlers();)
+```
+
+**설계 결정**: `registerAllEventHandlers()` **자체의 startup 호출(app 진입점)은 Phase 1.9 위임**. 1.7은 등록 함수를 호출 그래프에 **연결만** 하고(import + 본문 호출 해제), 실제 실행 활성화는 1.9 startup wiring에서 이뤄진다.
+
+---
+
+## 3. 데이터 설계
+
+### 3.1 Firestore 컬렉션/문서 구조
+
+| 컬렉션 | 문서 구조 | 용도 |
+|--------|----------|------|
+| `users/{userId}/notifications/settings` | (변경 없음) `AlarmSubscription` | **읽기만** — `getAllActiveSubscribers()`가 collectionGroup `notifications` + `enabled == true`로 조회 |
+
+> Phase 1.7은 Firestore에 쓰지 않는다. 스키마 변경 없음.
+
+### 3.2 이벤트 페이로드
+
+| 이벤트 타입 | 페이로드 | 발행 시점 |
+|------------|---------|----------|
+| `RECRUIT_NEW` (구독) | `RecruitNewEvent { timestamp, source?, addedJobs, updatedJobs, deletedIds }` | (Phase 1.3 발행분 수신) |
+| `NOTIFICATION_SEND` (발행) | `NotificationSendEvent { timestamp, source, userId, jobs: Job[], settings: AlarmSubscription }` | 구독자별 매칭 잡 ≥ 1건일 때 |
+
+---
+
+## 4. 구현 순서
+
+| 순서 | 작업 | 파일 | 설계 섹션 참조 |
+|------|------|------|--------------|
+| 1 | 모드/지역 필터 순수 함수 | `common/utils/recruitFilter.ts` (신규) | §2.1 |
+| 2 | 오케스트레이션 서비스 | `services/notificationService.ts` (신규) | §2.2 |
+| 3 | 이벤트 핸들러 | `events/bus/handlers/NotificationEventHandler.ts` (신규) | §2.3 |
+| 4 | 핸들러 등록 활성화 | `events/bus/utils/registerEventHandlers.ts` (수정) | §2.4 |
+
+---
+
+## 5. 코딩 컨벤션 체크리스트
+
+- [ ] camelCase 변수/함수, PascalCase 클래스/인터페이스/타입
+- [ ] SystemLogger 사용 (`globalLogger`, console.log 금지)
+- [ ] SystemError 패턴 준수 (핸들러 try-catch — 재throw 금지)
+- [ ] EventBus 타입 안전 이벤트 (`emitEvent<T>`/`onEvent<T>` 제네릭)
+- [ ] JSDoc 주석 (public API: `filterByMode`/`filterByRegion`/`notifyNewRecruits`/`registerNotificationHandlers`)
+- [ ] 한국어 주석 (정책·결정 사항)
+- [ ] 타입 SoT 재사용 (`AlertMode`/`AlarmSubscription`/`Job`/이벤트 페이로드 — 신규 타입 정의 금지)
+
+---
+
+## 6. 테스트 계획
+
+| 검증 항목 | 방법 | 기대 결과 |
+|----------|------|----------|
+| 타입 컴파일 | `npx tsc --noEmit` | 에러 없음 |
+| 기존 `RECRUIT_NEW` 발행부 무변경 | `recruitCacheService.ts` diff 확인 | 변경 없음 |
+| 핸들러 등록 연결 | `registerEventHandlers.ts` 호출 그래프 확인 | `registerNotificationHandlers` import + 호출 연결 |
+| 필터 — ALL 모드 | 수동 검증 | 전체 `targetJobs` 반환 |
+| 필터 — SELECTED 모드 (복수 지역) | 수동 검증 | 매칭 지역 공고만 반환 |
+| 필터 — 빈 지역(`regions: []`) | 수동 검증 | 0건 반환 |
+| 매칭 0건 구독자 | 수동 검증 | `NOTIFICATION_SEND` 미발행 |
+
+> **런타임 E2E 불가(알려진 갭)**: 1.7 단독으로는 1.8 DM sender·1.9 startup wiring 미완으로 실제 DM 전송을 검증할 수 없다. E2E 검증은 Phase 1.9 통합 시점으로 명시 — 1.7은 정적 검증(타입·등록 연결·필터 단위) 위주.
+
+---
+
+*작성일: 2026-06-09*
+*참고: docs/phase-1-7/01-plan.md*

--- a/docs/archive/phase-1-7/03-analysis.md
+++ b/docs/archive/phase-1-7/03-analysis.md
@@ -1,0 +1,140 @@
+# Phase 1.7 갭 분석: 자동 알림 시스템 (auto-notification-system)
+
+**상태**: 🔍 검토 중
+**분석일**: 2026-06-09
+**설계서**: `docs/phase-1-7/02-design.md`
+
+---
+
+## 1. 갭 분석 (Gap Detector)
+
+### 1.1 Structural (가중치 0.2)
+
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| S1 | §2.1 `recruitFilter.ts` 신규 파일 | 존재 | ✅ | `common/utils/recruitFilter.ts` |
+| S2 | §2.1 `filterByRegion(jobs, regions)` export | 존재, 시그니처 일치 | ✅ | recruitFilter.ts:26 |
+| S3 | §2.1 `filterByMode(jobs, subscription)` export | 존재, 시그니처 일치 | ✅ | recruitFilter.ts:48 |
+| S4 | §2.2 `notificationService.ts` 신규 파일 | 존재 | ✅ | `services/notificationService.ts` |
+| S5 | §2.2 `NotificationService` + `notifyNewRecruits` | 존재 | ✅ | notificationService.ts:17,26 |
+| S6 | §2.2 `notificationService` 싱글톤 export | 존재 | ✅ | notificationService.ts:47 |
+| S7 | §2.3 `NotificationEventHandler.ts` 신규 파일 | 존재 | ✅ | `events/bus/handlers/NotificationEventHandler.ts` |
+| S8 | §2.3 `registerNotificationHandlers()` export | 존재 | ✅ | NotificationEventHandler.ts:15 |
+| S9 | §2.4 `registerEventHandlers.ts` import 추가 | import 존재 | ✅ | registerEventHandlers.ts:10 |
+| S10 | §2.4 `registerEventHandlers.ts` 본문 호출 활성화 | 주석 해제·활성 호출 | ✅ | registerEventHandlers.ts:50 |
+
+### 1.2 Functional (가중치 0.4)
+
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| F1 | §2.2 잡셋 = addedJobs + updatedJobs 합집합 | `[...addedJobs, ...updatedJobs]` | ✅ | notificationService.ts:27 |
+| F2 | §2.2 빈 잡셋 조기 반환 | `if (targetJobs.length === 0) return;` | ✅ | notificationService.ts:28 |
+| F3 | §2.2 활성 구독자 조회 | `getAllActiveSubscribers()` | ✅ | notificationService.ts:30 |
+| F4 | §2.1 ALL→전체 / SELECTED→지역필터 | 삼항 분기 정확 | ✅ | recruitFilter.ts:48-52 |
+| F5 | §2.2 매칭 0건 구독자 미발행 | `if (matchedJobs.length === 0) continue;` | ✅ | notificationService.ts:34 |
+| F6 | §2.2 매칭 ≥1건 시 구독자별 발행 | 루프 내 emitEvent | ✅ | notificationService.ts:36 |
+| F7 | §2.1 빈 지역 0건 반환 | `if (regions.length === 0) return [];` | ✅ | recruitFilter.ts:27 |
+| F8 | §2.1 지역 매칭 = `title.includes(toKorean(region))` | 정확 + undefined 지명 필터 | ✅ | recruitFilter.ts:29-35 |
+| F9 | §2.3 핸들러 try-catch, 재throw 금지 | try-catch + globalLogger.error, 재throw 없음 | ✅ | NotificationEventHandler.ts:17-24 |
+| F10 | §2.2 생성자 리스너 등록 안 함(관심사 분리) | 생성자에 onEvent 없음 | ✅ | notificationService.ts:17-18 |
+| F11 | §2.2 동기 루프 구독자별 발행 | for-of 동기 루프 | ✅ | notificationService.ts:32-43 |
+
+### 1.3 Contract (가중치 0.4)
+
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| C1 | §3.2 `RecruitNewEvent` flat 구조 | `payload.addedJobs`/`payload.updatedJobs` 직접 접근 (SoT: extends JobDiffResult) | ✅ | types.ts:77 |
+| C2 | §3.2 `NotificationSendEvent` 5개 필드 | timestamp/source/userId/jobs/settings 모두 발행 | ✅ | types.ts:116-120 |
+| C3 | §5 `emitEvent<NotificationSendEvent>` 제네릭 | 명시 | ✅ | notificationService.ts:36 |
+| C4 | §2.3 `onEvent<RecruitNewEvent>` 제네릭 | 명시 | ✅ | NotificationEventHandler.ts:16 |
+| C5 | §5 `AlertMode` as const 사용 | `=== AlertMode.ALL` (SoT as const 객체) | ✅ | recruitFilter.ts:49 |
+| C6 | §5 `AlarmSubscription`/`Job`/`CityEn` SoT 재사용 | import만, 신규 정의 없음 | ✅ | recruitFilter.ts:8-11 |
+| C7 | §3.1 `getAllActiveSubscribers(): Promise<AlarmSubscription[]>` | 시그니처 일치, await | ✅ | subscription.ts:121 |
+| C8 | §3.2 `EventType.NOTIFICATION_SEND` 발행 | enum값 `"notification:send"` | ✅ | types.ts:28 |
+| C9 | §3.2 `EventType.RECRUIT_NEW` 구독 | enum값 `"recruit:new"` | ✅ | types.ts:21 |
+| C10 | §2.1 `filterByRegion` 시그니처 | 정확 일치 | ✅ | recruitFilter.ts:26 |
+| C11 | §2.1 `toKorean` 반환 undefined 처리 | 타입가드 필터링 | ✅ | recruitFilter.ts:31 |
+
+---
+
+## 2. 매치율 산출
+
+| 카테고리 | 일치/전체 | 점수 |
+|----------|----------|------|
+| Structural (×0.2) | 10/10 | 100% |
+| Functional (×0.4) | 11/11 | 100% |
+| Contract (×0.4) | 11/11 | 100% |
+| **종합 매치율** | | **100%** |
+
+### 산출 공식
+```
+종합 매치율 = Structural × 0.2 + Functional × 0.4 + Contract × 0.4
+           = 100 × 0.2 + 100 × 0.4 + 100 × 0.4 = 100%
+```
+
+---
+
+## 3. 갭 목록
+
+### 3.1 미구현 항목
+
+| # | 카테고리 | 설계 섹션 | 갭 내용 | 우선순위 |
+|---|----------|----------|--------|---------|
+| — | — | — | 정적 갭 없음 (설계-구현 완전 일치) | — |
+
+### 3.2 설계 차이
+
+| # | 설계 내용 | 실제 구현 | 판단 |
+|---|----------|----------|------|
+| — | (없음) | — | — |
+
+> **알려진 런타임 갭 (설계 명시, 정적 매치율과 무관)**: `registerAllEventHandlers()` startup 호출(1.9)·실제 DM 전송(1.8)은 의도적 제외. 1.7 단독 E2E DM 미동작은 갭이 아니라 설계된 이벤트 경계. E2E는 1.9 통합 시점.
+
+---
+
+## 4. 코드 품질 분석 (Code Analyzer)
+
+### 4.1 이슈 목록
+
+| # | 심각도 | 카테고리 | 파일:라인 | 이슈 내용 | 제안 |
+|---|--------|----------|----------|----------|------|
+| 1 | 🟡 Major | 컨벤션 | recruitFilter.ts:8-9 | import 경로 분리 — `Job`은 `@/common/types/job.d`, 나머지는 `@/common/types` 배럴. `Job`도 배럴 재노출됨 | `@/common/types` 한 경로로 통합 가능(권장) |
+| 2 | 🟡 Major | 정확성 | notificationService.ts:27 | `updatedJobs`(변경 공고)까지 알림 대상 — 중복 알림 체감 가능성 | **사용자 확정 사항**(addedJobs+updatedJobs). JSDoc 명시됨 — 조치 불요 |
+| 3 | 🟢 Minor | 성능 | notificationService.ts:30-43 | O(N·M) 선형 필터 + 구독자마다 `toKorean()` 반복 변환 | 규모 확장 시 koreanNames 캐싱/역인덱스 (현 단계 불요) |
+| 4 | 🟢 Minor | 컨벤션 | notificationService.ts:36 | EventBus 시그니처가 EventType↔페이로드 미연결(EventPayloadMap 미적용) — 코드 자체는 올바름 | EventBus 메서드 개선은 별도 사이클 후보 |
+| 5 | 🟢 Minor | 컨벤션 | notificationService.ts:1 | service가 `globalLogger` 직접 미사용인데 side-effect import 존재 | 추후 로깅 대비면 유지 무방 |
+
+### 4.2 컨벤션 준수
+
+| 항목 | 상태 | 비고 |
+|------|------|------|
+| SystemLogger(globalLogger) 사용 | ✅ | 핸들러 `globalLogger.error(msg, error, context)`, strict 통과 |
+| console.log 부재 | ✅ | 4개 파일 모두 console 직접 호출 없음 |
+| SystemError 패턴 | ✅(N/A) | 핸들러 try-catch + globalLogger.error로 충분(재throw 금지 목적) |
+| EventBus 제네릭 타입 안전 | ✅ | `emitEvent<T>`/`onEvent<T>` 명시 |
+| 타입 SoT 재사용 | ✅ | 신규 타입 중복 정의 0건 |
+| 네이밍 규칙 | ✅ | 함수 camelCase / 클래스 PascalCase / 파일명 규칙 준수 |
+| import 정리 | 🟡 | type/value import 혼재(이슈 #1) |
+| JSDoc (public API) | ✅ | 전 export JSDoc + 정책 출처 명시(모범) |
+| 레이어 의존 규칙 | ✅ | 필터 `common/utils` 배치 → services→features 금지 준수 |
+| 발행부 패턴 대칭성 | ✅ | `recruitCacheService` try-catch 패턴과 대칭 |
+
+### 4.3 요약
+- 🔴 Critical: 0건
+- 🟡 Major: 2건 (#1 import 일관성 / #2 변경 공고 알림 — 사용자 확정, 실질 조치 0)
+- 🟢 Minor: 3건 (모두 현 단계 액션 불요)
+
+---
+
+## 5. 다음 단계 분기
+
+✅ **매치율 100% (≥ 90%) AND 🔴 Critical 0건** → `/pdca report 1.7` 진행 가능
+
+- CTO Lead 사후 평가 생략 가능 (매치율 ≥ 90% AND Critical 0 — 비용 절감 규칙)
+- Major #1(import 통합)은 선택적 클린업 — report 전 즉시 반영 또는 보류 선택
+- (선택) 런타임 검증은 1.7 단독 불가(1.8/1.9 미완) → 1.9 통합 시점 권장
+
+---
+
+*분석일: 2026-06-09*
+*참고: docs/phase-1-7/02-design.md*

--- a/docs/archive/phase-1-7/04-report.md
+++ b/docs/archive/phase-1-7/04-report.md
@@ -1,0 +1,220 @@
+# Phase 1.7 완료 보고서: 자동 알림 시스템 (auto-notification-system)
+
+**상태**: 🔍 검토 중
+**작성일**: 2026-06-09
+**PDCA 사이클**: plan → design → do → analyze → report
+
+---
+
+## 1. 요약
+
+### 1.1 개요
+| 항목 | 내용 |
+|------|------|
+| 기능명 | 자동 알림 시스템 (Auto Notification System) |
+| Phase | 1.7 |
+| 시작일 | 2026-06-08 |
+| 완료일 | 2026-06-09 |
+| 최종 매치율 | 100% |
+| 반복 횟수 | 0 (1차 analyze에서 100% 달성) |
+
+### 1.2 목표 달성
+
+| 목표 | 달성 | 비고 |
+|------|------|------|
+| `RECRUIT_NEW` 이벤트 구독 | ✅ | `NotificationEventHandler.ts`에서 `eventBus.onEvent` 구현 |
+| 활성 구독자 조회 | ✅ | `SubscriptionStore.getAllActiveSubscribers()` 호출 |
+| 모드/지역 기반 필터링 | ✅ | `filterByMode()` + `filterByRegion()` 순수 함수 구현 |
+| 구독자별 `NOTIFICATION_SEND` 이벤트 발행 | ✅ | 매칭 공고 ≥ 1건 시 구독자별 발행 |
+| 핸들러 등록 활성화 (제외: startup 호출) | ✅ | `registerEventHandlers.ts`에서 호출 연결 |
+| 기존 `RECRUIT_NEW` 발행부 무변경 | ✅ | `recruitCacheService.ts` 변경 없음 |
+
+---
+
+## 2. 구현 요약
+
+### 2.1 주요 변경사항
+
+1. **RecruitFilter 필터 모듈** (`common/utils/recruitFilter.ts` — 신규)
+   - `filterByRegion(jobs, regions)`: `Job[]`를 입력받아 지역 필터링 (기존 `filterListByCity` 정책 재사용)
+   - `filterByMode(jobs, subscription)`: 구독자 모드에 따라 ALL(전체) / SELECTED(지역 매칭) 분기
+   - 순수 함수로 설계하여 테스트 가능성·DRY 확보
+
+2. **NotificationService 오케스트레이션** (`services/notificationService.ts` — 신규)
+   - `notifyNewRecruits(payload: RecruitNewEvent)`: 핵심 오케스트레이션 로직
+   - 잡셋 = `addedJobs + updatedJobs` 합집합 (사용자 확정 사항)
+   - 활성 구독자 조회 → 모드/지역별 필터 → 매칭 잡 ≥ 1건 시 구독자별 `NOTIFICATION_SEND` 발행
+
+3. **NotificationEventHandler 이벤트 핸들러** (`events/bus/handlers/NotificationEventHandler.ts` — 신규)
+   - `registerNotificationHandlers()`: `RECRUIT_NEW` 이벤트 구독 로직
+   - `try-catch` 에러 처리로 EventBus 안정성 확보 (재throw 금지, `globalLogger.error` 기록)
+   - `recruitCacheService` try-catch 패턴과 대칭
+
+4. **핸들러 등록 활성화** (`events/bus/utils/registerEventHandlers.ts` — 수정)
+   - import 추가: `registerNotificationHandlers` 호출 그래프 연결
+   - 본문 호출 주석 해제 (등록만, startup 호출은 Phase 1.9 위임)
+
+### 2.2 파일 변경 목록
+| 파일 | 변경 유형 | 라인 수 | 설명 |
+|------|----------|--------|------|
+| `functions/src/common/utils/recruitFilter.ts` | 신규 | ~52 | 모드/지역 필터 순수 함수 |
+| `functions/src/services/notificationService.ts` | 신규 | ~48 | 오케스트레이션 서비스 |
+| `functions/src/events/bus/handlers/NotificationEventHandler.ts` | 신규 | ~25 | 이벤트 핸들러 등록 |
+| `functions/src/events/bus/utils/registerEventHandlers.ts` | 수정 | +2 import, +1 호출 | 핸들러 등록 활성화 |
+
+**총 코드 라인**: ~127 lines
+
+---
+
+## 3. 갭 분석 이력
+
+### 3.1 분석 결과 요약
+| 분석 회차 | 매치율 | 갭 수 | 조치 |
+|----------|--------|-------|------|
+| 1차 | 100% | 0 | 반복 불필요 (설계-구현 완전 일치) |
+
+- Structural 10/10 (100%) · Functional 11/11 (100%) · Contract 11/11 (100%)
+- 종합 = 100×0.2 + 100×0.4 + 100×0.4 = **100%**
+
+### 3.2 주요 갭 해결 내역
+
+**정적 갭**: 0건 (설계-구현 일치도 100%)
+
+**알려진 런타임 갭** (설계 명시, 정적 매치율과 무관):
+- `registerAllEventHandlers()` startup 호출 (Phase 1.9 위임)
+- 실제 DM 발송 (Phase 1.8 영역)
+- 1.7 단독 E2E DM 검증 불가 — 이는 갭이 아니라 설계된 이벤트 경계
+
+---
+
+## 4. 검토 사항
+
+**참고 문서**: [review-process.md](../../.claude/rules/review-process.md)
+
+> ⚠️ 피드백 수신 시 즉시 반영하지 않음
+> 수정 계획 제시 → 사용자 승인 → 진행
+
+### 4.1 코드 리뷰
+
+- [x] 핵심 로직 구현 확인
+  - `filterByMode/filterByRegion` 순수 함수 + JSDoc 정책 출처 명시 ✅
+  - `notifyNewRecruits` 잡셋 = addedJobs+updatedJobs, 매칭 0건 미발행 ✅
+  - `registerNotificationHandlers` try-catch + `globalLogger.error` (재throw 금지) ✅
+
+- [x] 타입 안전성 확인
+  - `emitEvent<NotificationSendEvent>`, `onEvent<RecruitNewEvent>` 제네릭 타입 명시 ✅
+  - `AlertMode.ALL/SELECTED` as const enum 사용 ✅
+  - `AlarmSubscription`, `Job`, `CityEn` SoT 재사용 (신규 정의 0건) ✅
+
+- [x] 에러 처리 확인
+  - 핸들러 try-catch: EventBus 안정성, 재throw 금지 ✅
+  - `getAllActiveSubscribers()` 실패 시 핸들러 try-catch 흡수 ✅
+  - 개별 구독자 emit 실패가 루프 중단 안 함 ✅
+
+### 4.2 기능 테스트
+
+- [x] TypeScript 컴파일 성공
+  - `npx tsc --noEmit` 통과 ✅
+  - 4개 파일 모두 타입 에러 0건 ✅
+
+- [x] 기존 기능 정상 동작
+  - `recruitCacheService.ts` 변경 없음 ✅
+  - `RECRUIT_NEW` 발행 로직 무변경 ✅
+  - 다른 핸들러(`RecruitCacheEventHandler`) 영향 없음 ✅
+
+- [x] 런타임 E2E 검증 상태 (선택 사항, 미수행)
+  - **1.7 단독 E2E 불가**: `registerAllEventHandlers()` 호출(1.9)·DM 발송(1.8) 미완으로 실제 DM 전송 검증 불가
+  - **정적 검증 완료**: TypeScript 컴파일, 타입·핸들러 등록 연결, 필터 로직 검증
+  - **E2E 검증 시점**: Phase 1.9 통합(startup wiring + DM sender) 시 전체 흐름 활성화 후 검증 권장
+
+### 4.3 문서화
+
+- [x] JSDoc 주석 확인
+  - `filterByRegion` / `filterByMode` / `notifyNewRecruits` / `registerNotificationHandlers` 모두 JSDoc 작성 ✅
+  - 정책 출처 명시 (`filterListByCity` 참조 등) ✅
+
+- [x] 관련 문서 업데이트
+  - `docs/phase-1-7/01-plan.md` — 기본 계획서 작성 ✅
+  - `docs/phase-1-7/02-design.md` — 상세 설계서 작성 ✅
+  - `docs/phase-1-7/03-analysis.md` — 갭 분석 + Code Analyzer 완료 ✅
+
+---
+
+## 5. 코드 품질 분석 (Code Analyzer)
+
+### 5.1 이슈 요약
+- 🔴 **Critical**: 0건
+- 🟡 **Major**: 2건 (모두 사용자 확정 또는 선택적)
+- 🟢 **Minor**: 3건 (현 단계 액션 불요)
+
+### 5.2 주요 이슈
+
+| # | 심각도 | 카테고리 | 파일:라인 | 내용 | 판단 |
+|---|--------|----------|----------|------|------|
+| 1 | 🟡 Major | 컨벤션 | recruitFilter.ts:8-9 | import 경로 분리 (`Job`은 `@/common/types/job.d`, 나머지는 `@/common/types`) → `@/common/types` 통합 가능 | **report 전 이미 반영 완료** (import 통합) |
+| 2 | 🟡 Major | 정확성 | notificationService.ts:27 | `updatedJobs` 포함 시 중복 알림 가능성 | **사용자 확정 사항** (addedJobs+updatedJobs, 조치 불요) |
+| 3 | 🟢 Minor | 성능 | notificationService.ts:30-43 | O(N·M) 선형 필터, koreanNames 반복 변환 | 현 규모 충분, 확장 시 캐싱 검토 |
+| 4 | 🟢 Minor | 컨벤션 | notificationService.ts:36 | EventBus EventPayloadMap 미적용 (코드 정확) | EventBus 개선은 별도 사이클 후보 |
+| 5 | 🟢 Minor | 컨벤션 | notificationService.ts:1 | globalLogger side-effect import (직접 미사용) | 추후 로깅 용도로 유지 무방 |
+
+### 5.3 컨벤션 준수
+
+| 항목 | 상태 | 비고 |
+|------|------|------|
+| SystemLogger(globalLogger) 사용 | ✅ | 핸들러 `globalLogger.error(msg, error, context)` |
+| console.log 부재 | ✅ | 4개 파일 모두 console 직접 호출 없음 |
+| SystemError 패턴 | ✅ | 핸들러 try-catch + globalLogger로 충분 (재throw 금지) |
+| EventBus 제네릭 타입 안전 | ✅ | `emitEvent<T>` / `onEvent<T>` 명시 |
+| 타입 SoT 재사용 | ✅ | 신규 타입 중복 정의 0건 |
+| 네이밍 규칙 | ✅ | camelCase 함수 / PascalCase 클래스 / 파일명 규칙 준수 |
+| import 정리 | ✅ | Major #1 report 전 수정 완료 |
+| JSDoc (public API) | ✅ | 전 export JSDoc + 정책 출처 명시 |
+| 레이어 의존 규칙 | ✅ | 필터 `common/utils` 배치 → `services→features` 금지 준수 |
+| 발행부 패턴 대칭성 | ✅ | `recruitCacheService` try-catch 패턴과 대칭 |
+
+---
+
+## 6. 피드백 반영 내역
+
+(현재 없음 — 사용자 피드백 수신 시 기록)
+
+---
+
+## 7. Process Improvement
+
+### 7.1 잘된 점
+
+- **이벤트 경계 명확화**: 설계 단계에서 "Phase 1.7 = 이벤트 발행까지만"이라는 경계를 명시함으로써 1.8/1.9와의 의존성 충돌 없이 진행 가능 — 분할 구현의 모범 사례
+- **순수 함수 분리**: 필터 로직을 순수 함수(`filterByMode`/`filterByRegion`)로 분리하여 테스트 가능성, 재사용성, 정책 명확화 달성
+- **1차 분석 완전 통과**: design 설계가 충실하여 do 단계에서 정확히 구현, analyze 1차에서 100% 매치율 달성 (반복 0회)
+- **레이어 의존 규칙 준수**: `services→features` 금지 규칙을 인식하여 필터를 `common/utils`에 배치한 경로 교정 (plan과 CLAUDE.md 충돌 시 SoT 우선순위 활용)
+- **컨벤션 일관성**: `recruitCacheService`의 try-catch 패턴을 `NotificationEventHandler`에서 대칭적으로 구현하여 코드베이스 일관성 확보
+
+### 7.2 개선할 점
+
+- **Major #1 (import 통합)**: 타입 import 경로 분산(`job.d` vs 배럴)이 minor but recognizable — 초기 설계 단계에서 import 정책 리뷰 강화 (현재 report 전에 수정 완료)
+- **Runtime 검증 시점**: Phase 1.7은 설계상 E2E 검증 불가이나, 이를 사전에 plan 단계에서 명시할 수 있었음 — 다음 사이클부터 "알려진 갭" 구분 강화
+- **구독자 대량화 성능 설계**: 비기능 요구사항(성능)은 "소량 가정"으로만 정의, 구체적 임계값(예: 구독자 수 1,000→async 전환) 없음 — Phase 2.x에서 성능 개선 필요 시 상세 요구사항 정의
+
+### 7.3 다음 Phase 제안
+
+| 제안 | 관련 Phase | 우선순위 | 설명 |
+|------|-----------|---------|------|
+| `NOTIFICATION_SEND` 소비 → 실제 DM 발송 | Phase 1.8 | P0 | `NotificationSendEvent` 핸들러 구현, Discord.js 메시지 발송 로직 |
+| `registerAllEventHandlers()` startup 호출 | Phase 1.9 | P0 | 앱 진입점에서 전체 핸들러 등록 호출, E2E 활성화 |
+| 구독자 대량화 성능 최적화 | Phase 2.2 | P1 | 구독자 O(N) 조회 후 필터 O(M) — N·M 대형화 시 async/캐싱/역인덱스 검토 |
+
+---
+
+## 8. 다음 단계
+
+1. [ ] 사용자 피드백 확인 및 승인
+2. [ ] `/pdca archive 1.7` 실행 (문서 아카이브)
+3. [ ] `/pdca cleanup` 실행 (pdca-status.json 정리 + pdca-memory.json 초기화)
+4. [ ] Git 커밋(논리 단위) + push + PR 생성 (base dev) — archive/cleanup 변경 포함
+5. [ ] PR 머지 → dev 동기화 → `/pdca next`
+
+---
+
+*작성일: 2026-06-09*
+*참고: docs/phase-1-7/{01-plan.md, 02-design.md, 03-analysis.md}*

--- a/functions/src/common/utils/recruitFilter.ts
+++ b/functions/src/common/utils/recruitFilter.ts
@@ -1,0 +1,51 @@
+/**
+ * Recruit Filter Utility
+ *
+ * 자동 알림(Phase 1.7)에서 사용하는 모드/지역 필터 순수 함수.
+ * 구독자의 알림 모드(전체/선택)와 지역에 따라 새 공고(Job[])를 거른다.
+ */
+
+import type { Job, AlarmSubscription, CityEn } from "@/common/types";
+import { AlertMode } from "@/common/types";
+import { toKorean } from "@/common/utils/cityName";
+
+/**
+ * 지역 필터 (Pure Function)
+ *
+ * `filterListByCity`(common/utils/getCityFilteredList.ts)와 동일한
+ * `title.includes(한글지명)` 정책을 Job[]·복수 지역으로 확장한 어댑터.
+ * `filterListByCity`는 RecruitData[]·단일 city 시그니처라 Job[]에 직접 적용 시
+ * Job.id 손실 + 복수 지역 처리가 불가하여 별도 함수로 분리한다.
+ * (정책 출처를 본 JSDoc에 명시하여 드리프트 방지)
+ *
+ * @param jobs 대상 공고 목록
+ * @param regions 구독자 지역 목록 (영문 CityEn)
+ * @returns 지역에 매칭되는 공고만. 지역이 비어 있으면 빈 배열.
+ */
+export function filterByRegion(jobs: Job[], regions: CityEn[]): Job[] {
+  if (regions.length === 0) return [];
+
+  const koreanNames = regions
+    .map((region) => toKorean(region))
+    .filter((name): name is string => Boolean(name));
+
+  return jobs.filter((job) =>
+    koreanNames.some((koreanName) => job.value.title.includes(koreanName))
+  );
+}
+
+/**
+ * 모드 필터 (Pure Function)
+ *
+ * - `AlertMode.ALL` → 전체 공고 대상
+ * - `AlertMode.SELECTED` → 구독자 지역에 매칭되는 공고만
+ *
+ * @param jobs 대상 공고 목록
+ * @param subscription 구독자 알림 설정
+ * @returns 모드에 따라 필터링된 공고 목록
+ */
+export function filterByMode(jobs: Job[], subscription: AlarmSubscription): Job[] {
+  return subscription.alertMode === AlertMode.ALL
+    ? jobs
+    : filterByRegion(jobs, subscription.regions);
+}

--- a/functions/src/events/bus/handlers/NotificationEventHandler.ts
+++ b/functions/src/events/bus/handlers/NotificationEventHandler.ts
@@ -1,0 +1,26 @@
+import "@/common/utils/systemLogger"; // globalLogger 전역 등록
+import { eventBus, EventType } from "@/events/bus";
+import type { RecruitNewEvent } from "@/events/bus";
+import { notificationService } from "@/services/notificationService";
+
+/**
+ * 알림 이벤트 핸들러 등록 (Phase 1.7)
+ *
+ * `RECRUIT_NEW` → `notificationService.notifyNewRecruits` 를 연결한다.
+ *
+ * @remarks 핸들러 내부 try-catch로 EventBus 안정성을 확보한다(emitter로
+ *   재throw 금지) — `recruitCacheService`의 발행부 try-catch 패턴과 대칭.
+ *   `registerAllEventHandlers()` 자체의 startup 호출은 Phase 1.9에 위임.
+ */
+export function registerNotificationHandlers(): void {
+  eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, async (payload) => {
+    try {
+      await notificationService.notifyNewRecruits(payload);
+    } catch (error) {
+      globalLogger.error("알림 핸들러 처리 실패", error as Error, {
+        event: EventType.RECRUIT_NEW,
+        source: "NotificationEventHandler",
+      });
+    }
+  });
+}

--- a/functions/src/events/bus/utils/registerEventHandlers.ts
+++ b/functions/src/events/bus/utils/registerEventHandlers.ts
@@ -7,6 +7,7 @@
 
 import { eventBus } from '../EventBus';
 import { eventLogger } from './eventLogger';
+import { registerNotificationHandlers } from '../handlers/NotificationEventHandler';
 
 /**
  * 핸들러 등록 상태 추적
@@ -44,8 +45,9 @@ export function registerAllEventHandlers(): void {
   // Phase 1.3: RecruitCacheService 핸들러 (TODO)
   // registerRecruitHandlers();
 
-  // Phase 1.7: NotificationService 핸들러 (TODO)
-  // registerNotificationHandlers();
+  // Phase 1.7: NotificationService 핸들러
+  // 등록만 연결 — registerAllEventHandlers() 자체의 startup 호출은 Phase 1.9 위임
+  registerNotificationHandlers();
 
   // Phase 1.10: ProxyErrorHandler 핸들러 (TODO)
   // registerProxyErrorHandlers();

--- a/functions/src/services/notificationService.ts
+++ b/functions/src/services/notificationService.ts
@@ -1,0 +1,47 @@
+import "@/common/utils/systemLogger"; // globalLogger 전역 등록
+import { SubscriptionStore } from "@/providers/firebase/store/subscription";
+import { eventBus, EventType } from "@/events/bus";
+import type { RecruitNewEvent, NotificationSendEvent } from "@/events/bus";
+import { filterByMode } from "@/common/utils/recruitFilter";
+
+/**
+ * 자동 알림 오케스트레이션 서비스 (Phase 1.7)
+ *
+ * `RECRUIT_NEW` 수신 → 활성 구독자 조회 → 모드/지역 필터 → 구독자별
+ * `NOTIFICATION_SEND` 발행까지 담당한다.
+ *
+ * @remarks 설계 경계 = 이벤트 경계. 실제 DM 발송은 Phase 1.8 핸들러가
+ *   `NOTIFICATION_SEND`를 소비하여 수행하므로, 본 서비스 단독으로는 DM이
+ *   실제 전송되지 않는다(의도된 설계).
+ */
+export class NotificationService {
+  private readonly subscriptionStore = new SubscriptionStore();
+
+  /**
+   * 새 공고(추가 + 변경)를 활성 구독자별로 필터링하여
+   * 매칭 공고가 1건 이상인 구독자에게 `NOTIFICATION_SEND`를 발행한다.
+   *
+   * @param payload `RECRUIT_NEW` 이벤트 페이로드
+   */
+  async notifyNewRecruits(payload: RecruitNewEvent): Promise<void> {
+    const targetJobs = [...payload.addedJobs, ...payload.updatedJobs];
+    if (targetJobs.length === 0) return;
+
+    const subscribers = await this.subscriptionStore.getAllActiveSubscribers();
+
+    for (const subscriber of subscribers) {
+      const matchedJobs = filterByMode(targetJobs, subscriber);
+      if (matchedJobs.length === 0) continue;
+
+      eventBus.emitEvent<NotificationSendEvent>(EventType.NOTIFICATION_SEND, {
+        timestamp: Date.now(),
+        source: "NotificationService",
+        userId: subscriber.userId,
+        jobs: matchedJobs,
+        settings: subscriber,
+      });
+    }
+  }
+}
+
+export const notificationService = new NotificationService();


### PR DESCRIPTION
## Summary

크롤링이 새 공고를 감지해 발행하는 `RECRUIT_NEW` 이벤트(Phase 1.3)와 구독자 알림 설정 저장소(Phase 1.4) 사이의 **소비 계층 공백**을 메운다. `RECRUIT_NEW`를 구독해 활성 구독자별로 모드/지역 필터링 후 구독자별 `NOTIFICATION_SEND` 이벤트를 발행한다.

> **설계 경계 = 이벤트 경계**: Phase 1.7은 `NOTIFICATION_SEND` 발행까지만 담당. 실제 DM 발송은 Phase 1.8, `registerAllEventHandlers()` startup 호출은 Phase 1.9에 위임 → 1.7 단독으로는 DM이 실제 전송되지 않음(의도된 설계).

## 주요 변경사항

- **`common/utils/recruitFilter.ts`** (신규): `filterByMode`/`filterByRegion` 순수 함수. `filterListByCity`의 `title` 부분문자열 정책을 `Job[]`·복수 지역으로 확장
- **`services/notificationService.ts`** (신규): `notifyNewRecruits(payload)` — 잡셋(`addedJobs + updatedJobs`) → 활성 구독자 조회 → 필터 → 매칭 ≥1건 시 구독자별 `NOTIFICATION_SEND` 발행
- **`events/bus/handlers/NotificationEventHandler.ts`** (신규): `registerNotificationHandlers()` — `RECRUIT_NEW` 구독, try-catch로 EventBus 안정성 확보(재throw 금지)
- **`events/bus/utils/registerEventHandlers.ts`** (수정): import + 호출 연결 (등록만, startup 호출은 1.9)
- **`.gitignore`** (수정): `**/.claude/agent-memory/` — 중첩 경로(functions/ 등) 서브에이전트 메모리 무시 누락 수정
- **PDCA bookkeeping**: docs/phase-1-7 → docs/archive/phase-1-7, status JSON 정리(overview 9/25, Phase 1 75%)

## 기술적 개선사항

- 필터를 `common/utils`에 배치해 `services → features` 의존 금지 규칙 준수 (plan 원안 경로 교정, SoT 우선순위 적용)
- 핸들러 try-catch가 `recruitCacheService` 발행부 패턴과 대칭 — EventBus 안정성
- 타입 SoT 100% 재사용 (신규 타입 정의 0건)

## 테스트 상태

- ✅ `npx tsc --noEmit` 통과 (타입 에러 0)
- ✅ 갭 분석 매치율 **100%** (Structural/Functional/Contract 전부 100%), Code Analyzer Critical 0
- ✅ 기존 `RECRUIT_NEW` 발행부(`recruitCacheService`) 무변경
- ⏸️ 런타임 DM E2E: 1.7 단독 불가 (1.8 DM sender·1.9 startup wiring 미완) → 1.9 통합 시점 검증

## Breaking Changes

없음.