### PR TITLE
Phase 1.8: Discord DM 전송 유틸리티

### DIFF
--- a/.claude/docs/pdca-status.json
+++ b/.claude/docs/pdca-status.json
@@ -1,9 +1,9 @@
 {
   "overview": {
     "total": 25,
-    "completed": 9,
+    "completed": 10,
     "phases": {
-      "phase-1": { "completed": 9, "total": 12, "progress": "75%" },
+      "phase-1": { "completed": 10, "total": 12, "progress": "83%" },
       "phase-2": { "completed": 0, "total": 2, "progress": "0%" },
       "phase-3": { "completed": 0, "total": 5, "progress": "0%" },
       "phase-4": { "completed": 0, "total": 6, "progress": "0%" }
@@ -68,7 +68,7 @@
       { "features": "phase-1-5-notification-settings-ui", "phase": "archived", "matchRate": 98.3, "description": "/alarm-subscribe 슬래시 커맨드 UI 완성 — 모드(전체/선택) 전환, 지역 편집(SelectMenu), 알림 켜기/끄기 토글, U1+U3+U5 안정화(클릭 즉시 disabled + '⏳ 적용 중…' 라벨 + Firestore round-trip 3→2), 전역 에러 핸들러 dev/prod 분기 + 신규 헬퍼 disableMessageComponents", "startedAt": "2026-05-25", "completedAt": "2026-06-08", "documents": { "plan": "docs/archive/phase-1-5/01-plan.md", "design": "docs/archive/phase-1-5/02-design.md", "analysis": "docs/archive/phase-1-5/03-analysis.md", "report": "docs/archive/phase-1-5/04-report.md" } },
       { "features": "phase-1-6-recruit-request-enhancement", "phase": "archived", "matchRate": 100.0, "documents": { "plan": "docs/archive/phase-1-6/01-plan.md", "design": "docs/archive/phase-1-6/02-design.md", "analysis": "docs/archive/phase-1-6/03-analysis.md", "report": "docs/archive/phase-1-6/04-report.md" } },
       { "features": "phase-1-7-auto-notification-system", "phase": "archived", "matchRate": 100.0, "description": "RECRUIT_NEW 구독 → 활성 구독자 조회 → 모드/지역 필터(filterByMode/filterByRegion) → 구독자별 NOTIFICATION_SEND 발행 (이벤트 경계까지). 필터를 common/utils로 배치(services→features 금지 준수), 잡셋=addedJobs+updatedJobs. 실제 DM 발송은 1.8, startup wiring은 1.9 위임", "startedAt": "2026-06-08", "completedAt": "2026-06-09", "documents": { "plan": "docs/archive/phase-1-7/01-plan.md", "design": "docs/archive/phase-1-7/02-design.md", "analysis": "docs/archive/phase-1-7/03-analysis.md", "report": "docs/archive/phase-1-7/04-report.md" } },
-      { "features": "phase-1-8-discord-dm-utility", "phase": null, "matchRate": null, "documents": {} },
+      { "features": "phase-1-8-discord-dm-utility", "phase": "archived", "matchRate": 100.0, "description": "NOTIFICATION_SEND → 실제 Discord DM 전송 연결. dmSender(embeds 기반 포맷 무관 전송기, 재시도 3회+429 retry_after+50007 graceful skip) + 알림 임베드 빌더 + jobLink 공용 헬퍼(DRY) + NOTIFICATION_SEND 소비 핸들러(→NOTIFICATION_SENT 발행) + registerEventHandlers 등록 연결. sendNotificationDM 시그니처를 후속 Phase(1.9/1.10/2.1/2.2) 계약으로 격상. startup·client 로그인·E2E는 1.9 위임", "startedAt": "2026-06-09", "completedAt": "2026-06-10", "documents": { "plan": "docs/archive/phase-1-8/01-plan.md", "design": "docs/archive/phase-1-8/02-design.md", "analysis": "docs/archive/phase-1-8/03-analysis.md", "report": "docs/archive/phase-1-8/04-report.md" } },
       { "features": "phase-1-9-scheduler-reactivation", "phase": null, "matchRate": null, "documents": {} },
       { "features": "phase-1-10-proxy-integration", "phase": null, "matchRate": null, "documents": {} }
     ],

--- a/docs/archive/phase-1-8/01-plan.md
+++ b/docs/archive/phase-1-8/01-plan.md
@@ -1,0 +1,160 @@
+# Phase 1.8: Discord DM 발송 유틸리티
+
+**상태**: 🔄 진행 중
+**우선순위**: ⭐⭐⭐ (P0)
+**의존성**: 없음 (`NOTIFICATION_SEND` 이벤트 계약은 1.7에서 정의 완료)
+
+---
+
+## 개요
+
+### 배경
+Phase 1.7의 `NotificationService.notifyNewRecruits()`는 매칭된 구독자별로
+`NOTIFICATION_SEND` 이벤트(`{ userId, jobs: Job[], settings }`)를 발행하는 데서
+멈췄다(= 의도된 이벤트 경계). **현재 이 이벤트를 소비하는 핸들러가 없어 DM이
+실제로 전송되지 않는다.** 1.7 설계 주석과 메모리(`dm-e2e-test-phase-sequence`)는
+"실제 DM 발송 = 1.8, startup wiring = 1.9"로 경계를 명시했다.
+
+> **병목 노드(Bottleneck Node) 인식 — CTO Lead 게이트 반영.**
+> 1.8은 후속 4개 Phase(1.9·1.10·2.1·2.2)가 모두 의존하는 노드다. 특히 2.1(에러
+> 리포트)·2.2(관리자 공지)는 **관리자 DM에 `sendNotificationDM`을 재사용**한다.
+> 따라서 이번에 정의하는 **`sendNotificationDM` 시그니처가 4개 후속 Phase의 계약**이
+> 된다 → 단순 동작보다 **인터페이스(시그니처) 안정성이 최우선**이며, design 단계의
+> 1순위 안건은 "시그니처 고정"이다.
+
+### 목표
+`NOTIFICATION_SEND` → **실제 Discord DM 전송**까지 연결한다.
+- 포맷 무관 DM 전송기(`sendNotificationDM`) 구현 — 재시도·rate limit·에러 처리 포함.
+- `NOTIFICATION_SEND` 소비 핸들러로 임베드 빌드 → DM 전송 → `NOTIFICATION_SENT` 발행.
+- 핸들러 등록 연결(`registerEventHandlers`)까지. **startup 호출·client 로그인은 1.9 위임.**
+
+### 범위
+
+| 포함 | 제외 |
+|------|------|
+| `dmSender.ts` (전송 + 재시도 + 429 대기 + DM차단 처리) | client 로그인 / `registerAllEventHandlers()` startup 호출 (→ 1.9) |
+| `NOTIFICATION_SEND` 소비 핸들러 + `NOTIFICATION_SENT` 발행 | 런타임 E2E 검증 (→ 1.9 통합) |
+| 알림 전용 임베드 빌더 + jobLink 공용 헬퍼(DRY) | 교차 사용자 throttle/중앙 큐 (대규모 구독자 시 재검토) |
+| `registerEventHandlers`에 등록 연결 1줄 | 신규 이벤트 타입 정의 (기존 타입 재사용) |
+| `providers/CLAUDE.md` dmSender 예시 드리프트 정정 (§문서 정합성) | 부하/비용 실측 (→ 1.9 E2E 이월) |
+
+---
+
+## 요구사항
+
+### 기능 요구사항
+1. **`sendNotificationDM(userId, { embeds?, content? })`** — 기존 `client` 싱글톤으로
+   `users.fetch` → `user.send`. **완성된 `embeds`를 받아 보내는 포맷 무관 전송기**
+   (포맷을 시그니처에 박지 않음 — 후속 Phase 재사용 계약).
+2. **재시도/Rate Limit** — 최대 3회. 429는 `retry_after` 대기 후 재시도, 일시적 오류는
+   짧은 backoff. 구독자 간 간격은 discord.js v14 REST 내장 큐에 위임.
+3. **에러 처리** — 50007(DM 차단/공유 길드 없음)은 재시도 없이 graceful skip,
+   10013(Unknown User)은 재시도 없이 실패. 결과를 `DmSendResult`로 반환.
+4. **발송 로그** — `providerLogger`(LogSource `provider`)로 성공(userId/소요 시간)·
+   skip·실패 사유 기록. **`console.log` 금지(1.11 컨벤션).**
+5. **알림 임베드 빌더** — `notificationMessageEmbed(jobs)` ("🔔 새로운 채용 공고").
+6. **소비 핸들러** — `NOTIFICATION_SEND` 구독 → 임베드 빌드 → DM 전송 → `NOTIFICATION_SENT` 발행.
+
+### 비기능 요구사항
+- **인터페이스 안정성(최우선)**: `sendNotificationDM` 시그니처는 1.9/1.10/2.1/2.2의 계약 →
+  embeds 기반 포맷 무관 형태로 design에서 먼저 고정.
+- **성능/비용**: 핸들러는 emitter 안정성을 위해 내부 try-catch(재throw 금지).
+  순차 발송 시 `setTimeout` 블로킹이 함수 실행시간·비용에 영향 → §리스크 명시, 실측 1.9 이월.
+- **호환성**: 기존 `recruitMessageEmbed` 동작 동일 유지(헬퍼 추출 리팩터링만).
+- **에러 처리**: providers 계층은 graceful degradation, 조율은 events 계층 핸들러가 담당.
+
+---
+
+## 기술 스택 (프로젝트 고정)
+
+| 항목 | 기술 |
+|------|------|
+| Runtime | Firebase Functions (Node.js) |
+| Language | TypeScript (strict mode) |
+| Messaging | discord.js 14.x |
+| Event System | EventBus (Singleton) |
+| Logging | SystemLogger (`providerLogger`, LogSource `provider`) |
+
+---
+
+## 구현 전략
+
+### 접근 방식
+**전송기 1개 / 포맷 N개** 분리. `sendNotificationDM`은 완성된 `embeds`만 받아 전송·재시도·에러
+처리에 집중하고, 용도별 임베드 빌더를 따로 둔다. 향후 proxyError(1.10)·broadcast(2.2)·
+관리자 에러(2.1) DM은 빌더만 추가하면 같은 전송기로 발송된다.
+소비 핸들러는 1.7 `NotificationEventHandler` 패턴(내부 try-catch + `registerXHandlers`)과 대칭.
+
+### 영향 받는 파일
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `providers/discord/utils/dmSender.ts` | 신규 | `sendNotificationDM` — 전송·재시도·429대기·에러처리, `DmSendResult` 반환 |
+| `providers/discord/builder/embeds/notificationMessageEmbed.ts` | 신규 | `notificationMessageEmbed(jobs)` 알림 포맷 |
+| `providers/discord/builder/embeds/jobLink.ts` | 신규 | `extractJobId` / `formatJobTitleLink` 공용 헬퍼 (DRY 추출) |
+| `events/bus/handlers/NotificationSendHandler.ts` | 신규 | `registerNotificationSendHandlers()` — `NOTIFICATION_SEND` 소비 → DM → `NOTIFICATION_SENT` |
+| `events/bus/utils/registerEventHandlers.ts` | 수정 | 등록 호출 1줄 추가 (startup 호출은 1.9 유지) |
+| `providers/discord/builder/embeds/recruitMessageEmbed.ts` | 수정 | private `extractJobId` 제거 → `jobLink.ts` 헬퍼 사용 |
+| `functions/src/providers/CLAUDE.md` | 수정 | dmSender 예시 드리프트 정정 (§문서 정합성) |
+
+### 의존성 분석
+- **재사용**: `NotificationSendEvent`/`NotificationSentEvent`(types.ts), `client`(client.ts),
+  `providerLogger`(systemLogger), `recruitMessageEmbed` 링크 로직.
+- **계층 규칙**: dmSender(providers) → services/features 참조 금지. 조율은 events 핸들러.
+- **후속 의존(계약 소비자)**: 1.9(startup wiring + 스케줄러 재활성화), 1.10(proxyError DM),
+  2.1(관리자 에러 DM), 2.2(broadcast DM) — **모두 `sendNotificationDM` 시그니처 재사용**.
+
+### 문서 정합성 (CTO Lead 지적 #2 — 드리프트 정정)
+`functions/src/providers/CLAUDE.md`의 dmSender 예시가 확정 결정과 **모순**되어 정정 대상:
+- 예시 시그니처가 `sendNotificationDM(userId, { title, recruits, ... })` — **포맷이 시그니처에 박혀 있음**
+  → 확정 결정(포맷 무관 `{ embeds }`)과 충돌. 예시를 embeds 기반으로 교체.
+- 예시가 `console.log` 사용 → 1.11 컨벤션 위반. `providerLogger`로 교체.
+- 정정 시점: do 단계에서 코드와 함께 갱신(코드-문서 동시 수정 원칙).
+
+---
+
+## 위임 계획 (CTO Lead 게이트 반영)
+
+> CTO Lead 위임안 채택. 주 1(Discord Agent) + 보조 1(Integration Lead)로 압축.
+> 근거: `sendNotificationDM`이 4개 후속 Phase 계약이므로 인터페이스 안정성 우선 →
+> 도메인 전담 에이전트 분리가 방어적. 접점은 `sendNotificationDM` 시그니처 1개뿐이라
+> design에서 이를 먼저 고정하면 두 영역 병렬 작업 가능.
+
+| 영역 | 위임 대상 | 근거 | 예상 산출물 |
+|------|----------|------|-------------|
+| `dmSender.ts` 전송 유틸 (rate limit·429·50007·재시도) | **Discord Agent** | discord.js 14 REST/DMChannel·에러코드·rate limit 도메인, `providers/discord/**` | 포맷 무관 전송기 + 발송 로그(providerLogger) |
+| 알림 전용 임베드 빌더 + jobLink 헬퍼 | **Discord Agent** | EmbedBuilder 도메인, 전송기와 동일 에이전트가 포맷 작성 | `Job[]→APIEmbed` 빌더, 공용 링크 헬퍼 |
+| `NOTIFICATION_SEND` 소비 핸들러 + `NOTIFICATION_SENT` 발행 | **Integration Lead** | 이벤트 핸들러 = services↔providers 조율 계층, 1.7 try-catch/재throw 금지 패턴 유지 | 신규 핸들러 + 등록 함수 |
+| 등록 연결 검증 (1.9 startup 경계 유지) | **Integration Lead** | EventBus 배선, 1.9 경계 침범 방지 게이트 | 연결 확인 (startup 호출 금지) |
+
+> **병렬화 전제**: design에서 `sendNotificationDM` 시그니처 고정 → Discord/Integration 영역 동시 진행.
+
+---
+
+## 성공 기준
+
+- [ ] `sendNotificationDM` 시그니처가 embeds 기반 포맷 무관으로 고정 (후속 4개 Phase 계약)
+- [ ] `sendNotificationDM` 구현 (재시도 3회 + 429 `retry_after` 대기 + 50007/10013 처리)
+- [ ] `notificationMessageEmbed` + `jobLink` 헬퍼 (recruitMessageEmbed 동작 동일 유지)
+- [ ] `NOTIFICATION_SEND` 핸들러가 DM 전송 후 `NOTIFICATION_SENT` 발행
+- [ ] `registerEventHandlers`에 등록 연결 (startup 호출은 1.9)
+- [ ] `providers/CLAUDE.md` dmSender 예시 드리프트 정정 (embeds + providerLogger)
+- [ ] TypeScript 컴파일 성공 (baseline 외 새 에러 0건)
+- [ ] 기존 기능(`recruitMessageEmbed`) 정상 동작 확인
+
+---
+
+## 리스크 및 고려사항 (CTO Lead 게이트 반영)
+
+| # | 리스크 | 영향도 | 대응 방안 |
+|---|--------|--------|----------|
+| 1 | `sendNotificationDM` 시그니처가 2.1/2.2까지 4개 Phase 계약 → 오설계 시 광범위 재작업 | 🟡 중 | design 1순위로 시그니처 고정(embeds 기반). `providers/CLAUDE.md` 모순 정정 |
+| 2 | startup 미배선 → 정적 analyze만 가능, 실제 DM 전송 검증 불가 (1.9 병목) | 🟡 중 | analyze는 정적 매치율로 종결, 런타임 검증 1.9 명시 이월(`dm-e2e-test-phase-sequence`) |
+| 3 | 순차 발송 시 `setTimeout` 블로킹이 함수 실행시간·비용에 영향 | 🟢 저 | DM 단위 재시도 결정 유지, 부하 한계를 design §리스크 명시 + 실측 1.9 E2E 이월 |
+| 4 | 컨벤션 위반(console.log/LogSource) — `providers/CLAUDE.md` 예시가 console.log 사용 중 | 🟢 저 | 위임 시 providerLogger 명시, analyze에서 Code Analyzer가 검출 |
+| 5 | 헬퍼 추출로 recruitMessageEmbed 동작 변경 | 🟢 저 | 순수 추출(동작 동일 보장), 컴파일 + 시각 확인 |
+
+---
+
+*작성일: 2026-06-09*
+*시드: .claude/phases/phase-1-core.md*
+*게이트: CTO Lead plan 위임안 반영 (시그니처 계약 격상 / 문서 드리프트 정정 / 2-에이전트 위임 / 부하 리스크 명시)*

--- a/docs/archive/phase-1-8/02-design.md
+++ b/docs/archive/phase-1-8/02-design.md
@@ -1,0 +1,465 @@
+# Phase 1.8 설계서: Discord DM 발송 유틸리티
+
+**상태**: 🔄 진행 중
+**기반 문서**: `docs/phase-1-8/01-plan.md`
+
+---
+
+## 1. 아키텍처 설계
+
+### 1.1 레이어 매핑
+
+> 이 프로젝트는 단일 UI(Discord)만 존재하며, 실제 경로는 `providers/discord`, `events/bus`이다(템플릿 예시 경로 아님).
+
+| 프로젝트 레이어 | 변경 내용 |
+|----------------|----------|
+| Providers (`functions/src/providers/discord/`) | **신규** `utils/dmSender.ts` (`sendNotificationDM` + `DmSendResult`), **신규** `builder/embeds/notificationMessageEmbed.ts`, **신규** `builder/embeds/jobLink.ts`(공용 링크 헬퍼), **수정** `builder/embeds/recruitMessageEmbed.ts`(private `extractJobId` 제거 → 헬퍼 사용) |
+| EventBus Handlers (`functions/src/events/bus/handlers/`) | **신규** `NotificationSendHandler.ts` (`registerNotificationSendHandlers()` — `NOTIFICATION_SEND` 소비 → 임베드 빌드 → DM 전송 → `NOTIFICATION_SENT` 발행) |
+| EventBus Utils (`functions/src/events/bus/utils/`) | **수정** `registerEventHandlers.ts` (등록 호출 1줄 추가 — **startup 실제 호출·client 로그인은 Phase 1.9 위임**) |
+| Types (`functions/src/events/bus/types.ts`) | **변경 없음** (`NotificationSendEvent`/`NotificationSentEvent` 기존 재사용) |
+| Logging (`functions/src/common/utils/systemLogger.ts`) | **변경 없음** (`providerLogger` 재사용) |
+| 문서 (`functions/src/providers/CLAUDE.md`) | **수정 방향만 §5 명기** (실제 수정은 do 단계 — embeds 기반 + `providerLogger`로 드리프트 정정) |
+
+### 1.2 컴포넌트 다이어그램
+
+```
+[NotificationService]                  (services 계층 — 1.7, 변경 없음)
+   │  eventBus.emitEvent(NOTIFICATION_SEND, { userId, jobs, settings })
+   ▼
+[EventBus] ──────────────────────────────────────────────┐
+   │  onEvent(NOTIFICATION_SEND)                          │
+   ▼                                                      │
+[NotificationSendHandler]            (events/bus/handlers — 신규)
+   │  ① notificationMessageEmbed(jobs)  ──► [notificationMessageEmbed] (providers/builder)
+   │                                              │ jobLink 헬퍼 사용
+   │                                              ▼
+   │                                        [jobLink.ts] (공용 헬퍼 — recruitMessageEmbed도 공유)
+   │  ② sendNotificationDM(userId, { embeds }) ──► [dmSender] (providers/discord/utils)
+   │                                              │  client.users.fetch → user.send
+   │                                              │  재시도·429·50007·10013 처리
+   │                                              ▼ DmSendResult
+   │  ③ eventBus.emitEvent(NOTIFICATION_SENT, { userId, jobCount, success })
+   ▼
+[EventBus] (NOTIFICATION_SENT — 1.9+ 소비자 대상, 본 Phase는 발행만)
+```
+
+**계층 규칙 (계약)**: `dmSender`(providers)는 services/features를 참조하지 않는다. 조율(임베드 빌드 → 전송 → 결과 이벤트 발행)은 **events 핸들러**가 담당한다. 임베드는 호출 측(핸들러)이 빌더로 완성하여 전달하므로 `dmSender`는 포맷을 알지 못한다.
+
+---
+
+## 2. 상세 설계
+
+> **§2의 1순위 안건은 "시그니처 고정"이다.** `sendNotificationDM`은 후속 4개 Phase(1.9/1.10/2.1/2.2)의 계약이므로 **embeds 기반 포맷 무관** 형태로 아래에 명시적으로 고정한다.
+
+### 2.1 dmSender.ts — `sendNotificationDM` (계약 고정 ⭐)
+
+**파일**: `functions/src/providers/discord/utils/dmSender.ts`
+
+**인터페이스/타입 정의 (확정 계약 — 변경 시 4개 Phase 영향)**:
+
+```typescript
+import type { MessagePayload, MessageCreateOptions } from "discord.js";
+
+/**
+ * DM 발송 페이로드 — 포맷 무관(format-agnostic).
+ * 호출 측이 빌더로 완성한 embeds/content를 그대로 전달한다.
+ * 포맷(title/recruits 등)을 시그니처에 박지 않는다.
+ */
+export interface DmPayload {
+  /** 완성된 임베드 배열 (호출 측 빌더 산출물, 예: notificationMessageEmbed). */
+  embeds?: MessageCreateOptions["embeds"]; // = APIEmbed | JSONEncodable<APIEmbed> ... 배열
+  /** 임베드 대신/병행할 평문 메시지. */
+  content?: string;
+}
+
+/**
+ * DM 발송 결과 — 성공 / graceful skip / 실패 3분기.
+ * 호출 측(핸들러)이 NOTIFICATION_SENT 발행 여부·success 플래그를 판정하는 데 사용.
+ */
+export interface DmSendResult {
+  /** 전송 성공 여부. skip(=차단)도 success=false, skipped=true로 구분. */
+  ok: boolean;
+  /** DM 차단/공유 길드 없음(50007) 등 "보낼 수 없는 정상 상태" → 재시도·에러 아님. */
+  skipped?: boolean;
+  /** ok=false일 때 사유 코드/요약 (예: "dm_disabled" | "unknown_user" | "max_retries"). */
+  reason?: string;
+  /** Discord API 에러 코드 (50007 / 10013 등), 있으면 기록용. */
+  errorCode?: number;
+  /** 총 소요 시간(ms) — 로깅·관찰용. */
+  durationMs: number;
+  /** 실제 시도 횟수. */
+  attempts: number;
+}
+
+export async function sendNotificationDM(
+  userId: string,
+  payload: DmPayload
+): Promise<DmSendResult>;
+```
+
+**고정 시그니처 요약 (4개 Phase 계약)**:
+
+```
+sendNotificationDM(userId: string, payload: { embeds?; content? }): Promise<DmSendResult>
+```
+
+- 포맷(title/recruits)을 **시그니처에 박지 않는다**. 임베드는 호출 측이 빌더로 완성해 전달.
+- 반환은 `void`가 아닌 `DmSendResult` — 성공/skip/실패를 호출 측이 구분해 후속 이벤트를 결정.
+
+**상수**:
+
+```typescript
+const MAX_ATTEMPTS = 3;             // 최대 시도 횟수 (최초 1 + 재시도 2)
+const BASE_BACKOFF_MS = 500;        // 일시 오류 시 짧은 backoff 기준
+const ERR_DM_DISABLED = 50007;      // DM 차단 / 공유 길드 없음 → graceful skip
+const ERR_UNKNOWN_USER = 10013;     // Unknown User → 재시도 없이 실패
+```
+
+**핵심 로직 (pseudo-code)**:
+
+```typescript
+export async function sendNotificationDM(userId, payload): Promise<DmSendResult> {
+  const startedAt = Date.now();
+  let attempts = 0;
+
+  while (attempts < MAX_ATTEMPTS) {
+    attempts++;
+    try {
+      const user = await client.users.fetch(userId);
+      await user.send({ embeds: payload.embeds, content: payload.content });
+
+      const durationMs = Date.now() - startedAt;
+      providerLogger.info("DM 전송 성공", { userId, durationMs, attempts });
+      return { ok: true, durationMs, attempts };
+
+    } catch (error) {
+      const code = (error as { code?: number }).code;
+
+      // (1) DM 차단/공유 길드 없음 → 재시도 없이 graceful skip
+      if (code === ERR_DM_DISABLED) {
+        const durationMs = Date.now() - startedAt;
+        providerLogger.warn("DM 전송 skip (DM 차단/공유 길드 없음)", {
+          userId, errorCode: code, durationMs, attempts,
+        });
+        return { ok: false, skipped: true, reason: "dm_disabled", errorCode: code, durationMs, attempts };
+      }
+
+      // (2) Unknown User → 재시도 없이 실패
+      if (code === ERR_UNKNOWN_USER) {
+        const durationMs = Date.now() - startedAt;
+        providerLogger.error("DM 전송 실패 (Unknown User)", error as Error, {
+          userId, errorCode: code, durationMs, attempts,
+        });
+        return { ok: false, reason: "unknown_user", errorCode: code, durationMs, attempts };
+      }
+
+      // (3) Rate limit → 대기(ms, *1000 금지) 후 재시도
+      //     discord.js 14.17 RateLimitError.retryAfter/timeToReset은 밀리초 단위.
+      //     RateLimitError는 code가 없으므로 status===429 / name으로도 방어 감지.
+      const rateLimitWaitMs = getRateLimitWaitMs(error); // retryAfter/timeToReset(ms) 또는 fallback
+      if (rateLimitWaitMs != null) {
+        if (attempts >= MAX_ATTEMPTS) break;            // 마지막 시도였으면 실패 처리
+        await sleep(rateLimitWaitMs);                   // ms 그대로 — *1000 금지
+        continue;
+      }
+
+      // (4) 그 외 일시 오류 → 짧은 backoff 후 재시도 (마지막 시도면 break)
+      if (attempts >= MAX_ATTEMPTS) break;
+      await sleep(BASE_BACKOFF_MS * attempts);          // 선형 backoff
+      continue;
+    }
+  }
+
+  // 재시도 소진 → 실패
+  const durationMs = Date.now() - startedAt;
+  providerLogger.error("DM 전송 실패 (재시도 소진)", undefined, { userId, durationMs, attempts });
+  return { ok: false, reason: "max_retries", durationMs, attempts };
+}
+```
+
+> `client`는 `@/providers/discord/client`의 싱글톤 export를 직접 import(현재 `export const client = new Client(...)`). client 로그인(ready) 보장은 startup 책임 = **Phase 1.9 위임**. 본 Phase는 client가 로그인되었다는 전제에서 fetch/send만 수행한다.
+
+**에러 처리 원칙**:
+- providers 계층은 **graceful degradation** — 예외를 throw하지 않고 `DmSendResult`로 흡수해 반환한다 (조율 계층이 결과로 판단).
+- `console.log` 금지 — 성공(info)·skip(warn)·실패(error) 모두 `providerLogger`로만 기록.
+- **rate limit 대기 단위 = 밀리초(ms)**: discord.js 14.17 `RateLimitError.retryAfter`/`timeToReset`은 ms 단위다 — 원시 HTTP의 `retry_after`(초)와 달라 **`*1000` 보정 금지**. RateLimitError는 `code`가 없으므로 `retryAfter`/`timeToReset`(ms) → `status===429`/`name==="RateLimitError"` fallback 순으로 감지한다(`getRateLimitWaitMs` 헬퍼). 기본 설정(`rejectOnRateLimit: null`)에선 REST 내부 큐가 흡수해 실제 throw는 드물다. (do 단계 검증: 14.17.3 타입 정의 직접 확인 완료)
+
+### 2.2 notificationMessageEmbed.ts — 알림 전용 임베드 빌더
+
+**파일**: `functions/src/providers/discord/builder/embeds/notificationMessageEmbed.ts`
+
+**인터페이스**:
+
+```typescript
+import type { APIEmbed } from "discord.js";
+import type { Job } from "@/common/types/job.d";
+
+/** 새 공고 알림 DM용 임베드. "🔔 새로운 채용 공고" 헤더. */
+export function notificationMessageEmbed(jobs: Job[]): APIEmbed;
+```
+
+**핵심 로직 (pseudo-code)**:
+
+```typescript
+export function notificationMessageEmbed(jobs: Job[]): APIEmbed {
+  const baseUrl = ENV.SRIA_URL;
+  const embed = new EmbedBuilder()
+    .setTitle("🔔 새로운 채용 공고")
+    .setDescription(`총 ${jobs.length}건의 새로운 공고가 등록되었어요.`)
+    .setColor(0x00b0f4)
+    .setTimestamp();
+
+  jobs.forEach((job, index) => {
+    const r = job.value;                          // Job.value: RecruitData
+    const titleLine = formatJobTitleLink(r.title, r.href, baseUrl); // §2.3 공용 헬퍼
+    embed.addFields({
+      name: "\n",
+      value: `${index + 1}. ${titleLine}\n📅 ${r.dayTxt} | ⏱ ${r.dDay} | 🏷️ 상태: ${r.recruitmentStatus}`,
+    });
+  });
+
+  return embed.toJSON();
+}
+```
+
+> 입력은 `Job[]`(이벤트 페이로드 타입과 일치). `Job.value`가 `RecruitData`이므로 링크/필드는 `recruitMessageEmbed`와 동일 포맷을 공유한다. 표시 건수 상한(전체 vs 상위 N)·footer 정책은 do 단계에서 Frontend Architect와 확정(설계상은 매칭 공고가 보통 소수라 전체 표시 기본).
+
+**에러 처리**: 빌더는 순수 함수 — 외부 I/O 없음. 빈 배열 방어는 호출 측(핸들러)이 `jobs.length === 0` 시 발송 자체를 건너뛴다.
+
+### 2.3 jobLink.ts — 공용 링크 헬퍼 (DRY 추출)
+
+**파일**: `functions/src/providers/discord/builder/embeds/jobLink.ts`
+
+**인터페이스**:
+
+```typescript
+/** href("/jobs/12345")에서 jobId("12345") 추출. 매치 실패 시 "". */
+export function extractJobId(path: string): string;
+
+/**
+ * 공고 제목을 마크다운 링크로 포맷.
+ * baseUrl 없으면 링크 없이 제목만 반환(기존 recruitMessageEmbed 동작 동일).
+ */
+export function formatJobTitleLink(title: string, href: string, baseUrl?: string): string;
+```
+
+**핵심 로직 (pseudo-code)** — `recruitMessageEmbed`의 기존 로직을 **순수 추출**(동작 동일 유지):
+
+```typescript
+export function extractJobId(path: string): string {
+  const match = path.match(/\/jobs\/(\d+)/);
+  return match ? match[1] : "";
+}
+
+export function formatJobTitleLink(title: string, href: string, baseUrl?: string): string {
+  return baseUrl ? `[${title}](${baseUrl}${extractJobId(href)})` : title;
+}
+```
+
+> 기존 `recruitMessageEmbed`의 인라인 표현 `[${item.title}](${baseUrl}${extractJobId(item.href)})`를 그대로 `formatJobTitleLink`로 캡슐화한다. baseUrl 분기 동작도 동일. **동작 변경 없음**이 추출의 계약.
+
+### 2.4 recruitMessageEmbed.ts — 헬퍼 사용으로 리팩터링 (수정)
+
+**파일**: `functions/src/providers/discord/builder/embeds/recruitMessageEmbed.ts`
+
+**변경 내용**:
+- 파일 상단 private `function extractJobId(path)` **제거**.
+- `jobLink.ts`에서 `formatJobTitleLink`(또는 `extractJobId`) import.
+- 필드 생성부 `titleLine` 계산을 헬퍼 호출로 교체:
+
+```typescript
+import { formatJobTitleLink } from "./jobLink";
+// ...
+const titleLine = formatJobTitleLink(item.title, item.href, baseUrl);
+```
+
+**계약**: 출력 임베드 JSON은 변경 전과 **바이트 동일** 수준으로 유지(순수 추출). 컴파일 + 시각 확인으로 검증(§6).
+
+### 2.5 NotificationSendHandler.ts — 소비 핸들러 (신규)
+
+**파일**: `functions/src/events/bus/handlers/NotificationSendHandler.ts`
+
+**인터페이스**:
+
+```typescript
+/**
+ * NOTIFICATION_SEND 소비 핸들러 등록 (Phase 1.8).
+ * NOTIFICATION_SEND → 임베드 빌드 → sendNotificationDM → NOTIFICATION_SENT 발행.
+ */
+export function registerNotificationSendHandlers(): void;
+```
+
+**핵심 로직 (pseudo-code)** — 1.7 `NotificationEventHandler` 패턴과 대칭(내부 try-catch + 재throw 금지 + `globalLogger`):
+
+```typescript
+import "@/common/utils/systemLogger"; // globalLogger 전역 등록
+import { eventBus, EventType } from "@/events/bus";
+import type { NotificationSendEvent, NotificationSentEvent } from "@/events/bus";
+import { notificationMessageEmbed } from "@/providers/discord/builder/embeds/notificationMessageEmbed";
+import { sendNotificationDM } from "@/providers/discord/utils/dmSender";
+
+export function registerNotificationSendHandlers(): void {
+  eventBus.onEvent<NotificationSendEvent>(EventType.NOTIFICATION_SEND, async (payload) => {
+    try {
+      if (payload.jobs.length === 0) return;
+
+      const embed = notificationMessageEmbed(payload.jobs);
+      const result = await sendNotificationDM(payload.userId, { embeds: [embed] });
+
+      // skip(차단)도 success=false로 발행 — 1.9+ 소비자가 결과를 관찰
+      eventBus.emitEvent<NotificationSentEvent>(EventType.NOTIFICATION_SENT, {
+        timestamp: Date.now(),
+        source: "NotificationSendHandler",
+        userId: payload.userId,
+        jobCount: payload.jobs.length,
+        success: result.ok,
+        // result.ok=false일 때만 error 표기(skip은 정상 상태이므로 error 미부여 고려 — do에서 확정)
+      });
+    } catch (error) {
+      // emitter 안정성 — 재throw 금지
+      globalLogger.error("알림 발송 핸들러 처리 실패", error as Error, {
+        event: EventType.NOTIFICATION_SEND,
+        source: "NotificationSendHandler",
+      });
+    }
+  });
+}
+```
+
+**설계 결정 — `NotificationSentEvent.success` 매핑**:
+- `result.ok === true` → `success: true`.
+- `result.skipped === true`(DM 차단) → `success: false` (전송은 안 됐으나 시스템 정상). `error` 필드는 부여하지 않음(에러가 아님).
+- `result.ok === false && !skipped`(실패) → `success: false`. `error` 필드 부여는 do 단계에서 `NotificationSentEvent.error?: Error` 형태에 맞춰 확정(현재 페이로드는 `error?: Error` 옵셔널).
+
+**에러 처리**:
+- `dmSender`가 이미 graceful하게 `DmSendResult`를 반환하므로, 핸들러의 try-catch는 빌더 예외·예기치 못한 throw에 대한 **2차 안전망**.
+- 재throw 금지 — EventBus emitter로 예외가 전파되면 다른 리스너·프로세스 안정성을 해친다(1.7 패턴 동일).
+
+### 2.6 registerEventHandlers.ts — 등록 연결 (수정, 1.9 경계 준수)
+
+**파일**: `functions/src/events/bus/utils/registerEventHandlers.ts`
+
+**변경 내용** — `registerAllEventHandlers()` 내부에 **등록 호출 1줄만** 추가:
+
+```typescript
+import { registerNotificationSendHandlers } from "../handlers/NotificationSendHandler";
+// ...
+export function registerAllEventHandlers(): void {
+  // ... (기존)
+  registerNotificationHandlers();        // 1.7 (기존)
+
+  // Phase 1.8: NOTIFICATION_SEND 소비 핸들러 (DM 발송)
+  registerNotificationSendHandlers();    // ← 추가
+  // ...
+}
+```
+
+> **⚠️ 1.9 경계 명시 (CTO 리스크 반영)**: 본 Phase는 `registerAllEventHandlers()` 내부에 **핸들러 등록 연결만** 추가한다.
+> - `registerAllEventHandlers()`를 **startup(app 진입점)에서 실제 호출**하는 것 → **Phase 1.9**.
+> - **Discord client 로그인(`client.login`)·ready 보장** → **Phase 1.9**.
+> 즉 1.8 종료 시점에는 "핸들러가 등록되도록 배선만 완료"되며, 실제 DM이 나가려면 1.9의 startup wiring이 필요하다. design은 이 경계를 침범하지 않는다.
+
+---
+
+## 3. 데이터 설계
+
+### 3.1 Firestore 컬렉션/문서 구조
+
+해당 없음 — 본 Phase는 Firestore 읽기/쓰기 없음(구독자 조회는 1.7 `NotificationService` 책임, 본 Phase는 이미 발행된 `NOTIFICATION_SEND`만 소비).
+
+### 3.2 이벤트 페이로드 (기존 타입 재사용 — 신규 정의 없음)
+
+| 이벤트 타입 | 방향 | 페이로드 | 발행/소비 시점 |
+|------------|------|---------|---------------|
+| `NOTIFICATION_SEND` (`notification:send`) | **소비** | `NotificationSendEvent { timestamp, source?, userId, jobs: Job[], settings: AlarmSubscription }` | 1.7 `NotificationService.notifyNewRecruits`가 구독자별 발행 → 본 Phase 핸들러가 소비 |
+| `NOTIFICATION_SENT` (`notification:sent`) | **발행** | `NotificationSentEvent { timestamp, source?, userId, jobCount, success, error? }` | 본 Phase 핸들러가 DM 전송(또는 skip/실패) 후 발행. 소비자는 1.9+ (본 Phase는 발행만) |
+
+**페이로드 매핑 (핸들러 내부)**:
+
+| `NotificationSentEvent` 필드 | 값 |
+|------------------------------|-----|
+| `timestamp` | `Date.now()` |
+| `source` | `"NotificationSendHandler"` |
+| `userId` | `payload.userId` |
+| `jobCount` | `payload.jobs.length` |
+| `success` | `DmSendResult.ok` (skip·실패 모두 `false`) |
+| `error?` | 실패 시에만 부여 검토(skip은 미부여) — do 단계 확정 |
+
+> `DmSendResult`(§2.1)는 **provider 내부 반환 타입**이며 EventBus 페이로드가 아니다. 신규 이벤트 타입을 정의하지 않는다(범위 제외 준수).
+
+---
+
+## 4. 구현 순서
+
+> **시그니처 우선 고정 → 병렬 가능.** 1번(계약 고정) 완료 후 Discord 영역(2~4)과 Integration 영역(5~6)을 병렬 진행할 수 있다.
+
+| 순서 | 작업 | 파일 | 병렬 | 설계 섹션 |
+|------|------|------|------|----------|
+| 1 | **`DmSendResult`/`DmPayload` 타입 + `sendNotificationDM` 시그니처 고정** (계약 — 최우선) | `providers/discord/utils/dmSender.ts` | — | §2.1 |
+| 2 | `jobLink.ts` 공용 헬퍼 추출 (순수) | `providers/discord/builder/embeds/jobLink.ts` | 🟢 A | §2.3 |
+| 3 | `recruitMessageEmbed` 헬퍼 사용으로 교체 | `providers/discord/builder/embeds/recruitMessageEmbed.ts` | 🟢 A (2 의존) | §2.4 |
+| 4 | `notificationMessageEmbed` 빌더 + `sendNotificationDM` 본문 구현 | `notificationMessageEmbed.ts`, `dmSender.ts` | 🟢 A | §2.1, §2.2 |
+| 5 | `NotificationSendHandler` 구현 (NOTIFICATION_SEND 소비 → DM → SENT 발행) | `events/bus/handlers/NotificationSendHandler.ts` | 🔵 B (1 시그니처 의존) | §2.5 |
+| 6 | `registerEventHandlers`에 등록 연결 1줄 (startup 호출 X — 1.9) | `events/bus/utils/registerEventHandlers.ts` | 🔵 B | §2.6 |
+| 7 | `providers/CLAUDE.md` dmSender 예시 드리프트 정정 (코드-문서 동시) | `providers/CLAUDE.md` | — | §5 |
+| 8 | TypeScript 컴파일 검증 (baseline 외 신규 에러 0건) | 전체 | — | §6 |
+
+> 🟢 A = Discord Agent 영역 / 🔵 B = Integration Lead 영역. 접점은 `sendNotificationDM` 시그니처 1개(순서 1)뿐 → 고정 후 A·B 동시 진행.
+
+---
+
+## 5. 코딩 컨벤션 체크리스트
+
+- [ ] camelCase 변수/함수, PascalCase 인터페이스/타입 (`DmSendResult`, `DmPayload`)
+- [ ] **`console.log` 금지** → `providerLogger`(LogSource `provider`)로 성공(info)/skip(warn)/실패(error) 기록
+- [ ] 핸들러 로깅은 `globalLogger`(1.7 패턴 대칭, `import "@/common/utils/systemLogger"` 선행)
+- [ ] EventBus 타입 안전 메서드(`emitEvent<T>`/`onEvent<T>`) + `EventType` enum 사용
+- [ ] 핸들러 내부 try-catch + **재throw 금지**(emitter 안정성)
+- [ ] providers 계층 의존성 규칙: `dmSender` → services/features 참조 금지
+- [ ] 신규 이벤트 타입 정의 금지(기존 `NotificationSendEvent`/`NotificationSentEvent` 재사용)
+- [ ] JSDoc 주석(공개 API: `sendNotificationDM`, `DmSendResult`, 빌더, 헬퍼)
+- [ ] 한국어 사용자 대면 문자열("🔔 새로운 채용 공고" 등)
+
+### 5.1 `providers/CLAUDE.md` 드리프트 정정 방향 (실제 수정은 do 단계)
+
+현재 `functions/src/providers/CLAUDE.md`의 `dmSender.ts` 예시가 확정 계약과 **모순** → do 단계에서 코드와 함께 정정:
+
+| 현재(드리프트) | 정정 방향 |
+|---------------|----------|
+| `sendNotificationDM(userId, { title, recruits, color })` — **포맷이 시그니처에 박힘** | `sendNotificationDM(userId, { embeds?, content? }): Promise<DmSendResult>` — **포맷 무관** (§2.1 확정 계약) |
+| `console.log` / `console.error` 사용 | `providerLogger.info/warn/error` 사용 (LogSource `provider`) |
+| `Promise<void>` 반환 | `Promise<DmSendResult>` 반환(성공/skip/실패 구분) |
+| `sendBulkNotifications` + `setTimeout(1000)` 순차 발송 예시 | 구독자 간 간격은 discord.js v14 REST 내장 큐에 위임 — bulk 헬퍼는 본 Phase 범위 아님(예시 제거/축약). 순차 발송 비용은 §리스크 + 1.9 실측 이월 |
+| `error.code === 50007`만 처리 | 50007(graceful skip) + 10013(실패) + rate limit(ms 대기, RateLimitError는 code 없음) 명시 |
+
+---
+
+## 6. 테스트 계획
+
+> Phase 3 테스트 프레임워크 도입 전 — **수동/컴파일 검증**. 런타임 E2E(실제 DM 전송)는 startup wiring 의존이므로 **Phase 1.9 이월**(메모리 `dm-e2e-test-phase-sequence` 일치).
+
+| 검증 항목 | 방법 | 기대 결과 |
+|----------|------|----------|
+| 전체 컴파일 | `tsc` / `npm run build` | baseline 외 신규 에러 0건 |
+| `sendNotificationDM` 시그니처 고정 | 타입 확인 (`DmPayload`/`DmSendResult`) | embeds 기반 포맷 무관, `Promise<DmSendResult>` 반환 |
+| `recruitMessageEmbed` 동작 동일 | 헬퍼 추출 전/후 임베드 JSON 비교(수동 diff) | 출력 변경 없음 |
+| `notificationMessageEmbed` 산출 | 샘플 `Job[]`로 호출 → JSON 육안 확인 | "🔔 새로운 채용 공고" 헤더 + 공고 필드/링크 정상 |
+| 핸들러 등록 연결 | `registerAllEventHandlers()` 코드상 호출 확인 | `registerNotificationSendHandlers()` 1줄 추가, startup 호출은 미포함(1.9) |
+| 에러 분기 (로직 검토) | 코드 리뷰 | 50007 skip / 10013 실패 / rate limit ms 대기(*1000 금지) / 미지 코드 backoff 재시도 |
+| 컨벤션 | 코드 리뷰 / Code Analyzer | `console.log` 0건, `providerLogger`/`globalLogger` 사용 |
+| **런타임 DM 전송 E2E** | **(이월)** | **Phase 1.9 startup wiring 후 실제 DM 수신 확인** |
+
+### 6.1 1.9 이월 명시 (런타임 검증 불가 사유)
+
+본 Phase는 `registerAllEventHandlers()`의 **startup 호출과 client 로그인을 포함하지 않으므로**(1.9 경계) 정적 검증(컴파일·코드 리뷰)까지만 가능하다. 실제 DM 전송 검증은 1.9 통합 시 수행한다.
+
+### 6.2 리스크/비고 (do·analyze 참고)
+
+- **순차 발송 + `setTimeout` 블로킹**: 핸들러는 구독자별 `NOTIFICATION_SEND` 단위로 독립 호출되나, 429 시 `retry_after` 대기(`sleep`)가 해당 핸들러 실행을 블로킹한다. 다수 구독자·rate limit 누적 시 함수 실행시간·비용에 영향 → **실측은 1.9 E2E 이월**(plan §리스크 3). 교차 사용자 throttle/중앙 큐는 본 Phase 범위 제외.
+- **client ready 전제**: dmSender는 client 로그인 완료를 전제한다. 미로그인 상태 호출 시 fetch 실패 → 1.9 startup이 ready 보장.
+
+---
+
+*작성일: 2026-06-10*
+*참고: docs/phase-1-8/01-plan.md*
+*게이트: CTO Lead design 위임안 반영 (Discord Agent 단독 작성 §1~§6, NotificationSendHandler는 Integration Lead 추후 검토)*

--- a/docs/archive/phase-1-8/03-analysis.md
+++ b/docs/archive/phase-1-8/03-analysis.md
@@ -1,0 +1,141 @@
+# Phase 1.8 갭 분석: Discord DM 발송 유틸리티
+
+**상태**: 🔍 검토 중
+**분석일**: 2026-06-10
+**설계서**: `docs/phase-1-8/02-design.md` (rate limit ms 정정 완료본)
+
+---
+
+## 1. 갭 분석 (Gap Detector)
+
+설계 ↔ 구현 7파일. 확정 결정(I-2 rate limit ms / I-3 타입 변경 없음 / I-4 상위 3개+외 N건)은 의도된 설계로 간주하여 일치 판정.
+
+### 1.1 Structural (가중치 0.2)
+
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| S1 | §2.1 `dmSender.ts` 신규 — `sendNotificationDM`+`DmPayload`+`DmSendResult` export | 3개 export 존재 | ✅ | `providers/discord/utils/dmSender.ts` |
+| S2 | §2.3 `jobLink.ts` 신규 — `extractJobId`+`formatJobTitleLink` | 2개 export 존재 | ✅ | `builder/embeds/jobLink.ts` |
+| S3 | §2.2 `notificationMessageEmbed.ts` 신규 | 존재 | ✅ | `builder/embeds/notificationMessageEmbed.ts` |
+| S4 | §2.4 `recruitMessageEmbed.ts` — private `extractJobId` 제거, 헬퍼 import | private 제거 + `formatJobTitleLink` import | ✅ | `builder/embeds/recruitMessageEmbed.ts` |
+| S5 | §2.5 `NotificationSendHandler.ts` 신규 — `registerNotificationSendHandlers()` | 존재 | ✅ | `events/bus/handlers/NotificationSendHandler.ts` |
+| S6 | §2.6 `registerEventHandlers.ts` — 등록 호출 1줄 | line 55 등록 + import 추가 | ✅ | `events/bus/utils/registerEventHandlers.ts` |
+| S7 | §5.1 `providers/CLAUDE.md` 드리프트 정정 | embeds 기반+`providerLogger`로 정정 | ✅ | `providers/CLAUDE.md` |
+| S8 | §1.1/§3.2 types.ts 변경 없음 (신규 이벤트 타입 금지) | 기존 타입 그대로, 신규 0건 | ✅ | `events/bus/types.ts` |
+
+### 1.2 Functional (가중치 0.4)
+
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| F1 | §2.1 재시도 최대 3회 | `MAX_ATTEMPTS=3`, `while(attempts<3)` | ✅ | dmSender.ts |
+| F2 | §2.1 50007 → graceful skip + `warn` | `skipped:true,reason:"dm_disabled"`+`.warn` 즉시 return | ✅ | dmSender.ts |
+| F3 | §2.1 10013 → 실패 + `error` | `reason:"unknown_user"`+`.error` 즉시 return | ✅ | dmSender.ts |
+| F4 | §2.1 rate limit ms 대기 (`*1000` 금지) | `getRateLimitWaitMs`→ms 그대로 `sleep`, `*1000` 없음 | ✅ | dmSender.ts |
+| F5 | §2.1 rate limit 감지 — RateLimitError(code 없음)→retryAfter/timeToReset→status/name fallback | ms 추출 후 `status===429\|\|name` fallback(1000ms) | ✅ | dmSender.ts |
+| F6 | §2.1 default 미지 코드 → 선형 backoff 재시도 | `sleep(BASE_BACKOFF_MS*attempts)` | ✅ | dmSender.ts |
+| F7 | §2.1/§5 providerLogger info/warn/error, console.log 0건 | 매핑 정확, console 0건 | ✅ | dmSender.ts |
+| F8 | §2.5 NOTIFICATION_SEND 소비→임베드→DM→NOTIFICATION_SENT 발행 | `onEvent`→빌드→`sendNotificationDM`→`emitEvent` | ✅ | NotificationSendHandler.ts |
+| F9 | §2.2/§2.5 빈 배열 방어 | `if(jobs.length===0) return;` | ✅ | NotificationSendHandler.ts |
+| F10 | §2.5 1.7 패턴 대칭 — try-catch+재throw 금지, `globalLogger` | 재throw 없음 | ✅ | NotificationSendHandler.ts |
+| F11 | §2.4 recruitMessageEmbed 동작 동일 (순수 추출) | 링크만 헬퍼 교체, 출력 로직 동일 | ✅ | recruitMessageEmbed.ts |
+| F12 | §2.2 상위 3개+외 N건 (I-4) | `slice(0,3)`+`length>=6` 시 "외 N건" | ✅ | notificationMessageEmbed.ts |
+| F13 | §2.5 NOTIFICATION_SENT.success — skip도 false | `success:result.ok` | ✅ | NotificationSendHandler.ts |
+
+### 1.3 Contract (가중치 0.4)
+
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| C1 | §2.1 ⭐ `sendNotificationDM(userId, {embeds?,content?}): Promise<DmSendResult>` 포맷 무관 고정 | 시그니처 정확 일치, title/recruits 미박힘 | ✅ | dmSender.ts |
+| C2 | §2.1 `DmPayload` 형태 | 동일 | ✅ | dmSender.ts |
+| C3 | §2.1 `DmSendResult` 6필드 | 동일 | ✅ | dmSender.ts |
+| C4 | §3.2 NotificationSentEvent 기존 타입 유지 (I-3) | types.ts 그대로 | ✅ | types.ts |
+| C5 | §3.2 NOTIFICATION_SENT 페이로드 매핑 | timestamp/source/userId/jobCount/success/error? 준수 | ✅ | NotificationSendHandler.ts |
+| C6 | §2.5 skip은 success=false + error 미부여 (I-3) | 조건부 spread로 skip 시 error 미부여 | ✅ | NotificationSendHandler.ts |
+| C7 | §2.2 `notificationMessageEmbed(jobs): APIEmbed` | 동일, `Job.value` 사용 | ✅ | notificationMessageEmbed.ts |
+| C8 | §2.3 `extractJobId`/`formatJobTitleLink` 시그니처 | 동일 | ✅ | jobLink.ts |
+| C9 | §1.1 providers → services/features 참조 금지 | 위반 없음 | ✅ | dmSender.ts |
+| C10 | §2.6 1.9 경계 — startup 호출·client.login 미추가 | 등록만, startup/login 코드 없음 | ✅ | registerEventHandlers.ts |
+| C11 | §2.1 client 싱글톤 직접 import | `@/providers/discord/client` | ✅ | dmSender.ts |
+
+---
+
+## 2. 매치율 산출
+
+| 카테고리 | 일치/전체 | 점수 |
+|----------|----------|------|
+| Structural (×0.2) | 8/8 | 100% |
+| Functional (×0.4) | 13/13 | 100% |
+| Contract (×0.4) | 11/11 | 100% |
+| **종합 매치율** | **32/32** | **100%** |
+
+### 산출 공식
+```
+종합 매치율 = Structural × 0.2 + Functional × 0.4 + Contract × 0.4
+            = 100 × 0.2 + 100 × 0.4 + 100 × 0.4 = 100.0%
+```
+
+---
+
+## 3. 갭 목록
+
+### 3.1 미구현 항목
+
+| # | 카테고리 | 설계 섹션 | 갭 내용 | 우선순위 |
+|---|----------|----------|--------|---------|
+| — | — | — | **갭 없음 (32/32 완전일치)** | — |
+
+🔴 Critical 갭: **0건**
+
+### 3.2 설계 차이
+
+| # | 설계 내용 | 실제 구현 | 판단 |
+|---|----------|----------|------|
+| 1 | §2.1 pseudo-code에 fallback 상수 없음 | `FALLBACK_RATE_LIMIT_MS=1000`(ms) 추가 | 허용 — 설계 본문 "fallback 순으로 감지" 의도와 정합, ms 단위라 버그 아님 |
+
+---
+
+## 4. 코드 품질 분석 (Code Analyzer)
+
+### 4.1 이슈 목록
+
+| # | 심각도 | 카테고리 | 파일:라인 | 이슈 내용 | 제안 |
+|---|--------|----------|----------|----------|------|
+| 1 | 🟡 | DRY | `notificationMessageEmbed.ts` ↔ `recruitMessageEmbed.ts` | 공고 1줄 렌더링 포맷(번호+날짜/D-Day/상태)이 두 임베드에 잔존 중복(링크는 jobLink로 통합됨) | 입력 타입(`Job` vs `RecruitData`)·출력 포맷 차이로 **강제 통합 비권장** — Info 수준 |
+| 2 | 🟡 | 품질 | `recruitMessageEmbed.ts:28-31` | 필드 value 템플릿 리터럴에 선행 공백·개행 잔존 (기존 코드) | 1.8 범위 밖 기존 결함, 회귀 위험 시 별도 처리 |
+| 3 | 🟢 | 품질 | `dmSender.ts:59-62` | `getErrorCode` unknown 캐스팅 (strict 안전) | `DiscordAPIError` instanceof 분기 고려 — 변경 불필요 |
+| 4 | 🟢 | 품질 | `dmSender.ts:114-186` | 분기별 `Date.now()-startedAt`/return 객체 boilerplate | 각 분기 의도 명확 — 유지 권장 |
+| 5 | 🟢 | 컨벤션 | `registerEventHandlers.ts` (기존부) | 기존 `as any`·이모지 로그 잔존 (1.8 신규 라인은 깨끗) | 본 Phase 범위 밖 |
+
+### 4.2 컨벤션 준수
+
+| 항목 | 상태 | 비고 |
+|------|------|------|
+| SystemLogger 사용 (console.log 금지) | ✅ | dmSender providerLogger, 핸들러 globalLogger. console 0건 |
+| LogSource 타입 제약 (provider) | ✅ | providerLogger 프리셋 |
+| 네이밍 규칙 (camel/Pascal/UPPER_SNAKE) | ✅ | 일관 |
+| JSDoc (public API) | ✅ | 전 public 함수 한국어 JSDoc |
+| import 정리 | ✅ | external→@/internal→relative→type 순 |
+| 계층 규칙 (providers→services/features 금지) | ✅ | 위반 없음 |
+| 타입 안전성 (strict) | ✅ | 통과 |
+| EventBus 패턴 (제네릭·루프 없음) | ✅ | onEvent/emitEvent 제네릭, 다른 이벤트 발행으로 루프 없음 |
+
+### 4.3 요약
+
+- 🔴 Critical: **0건**
+- 🟡 Warning: **2건** (둘 다 기존 코드 영역 잔여 중복/포맷, 강제 통합 시 회귀 위험 → Info 준함)
+- 🟢 Info: **3건**
+
+---
+
+## 5. 다음 단계 분기
+
+✅ **매치율 100% (≥ 90%) AND 🔴 Critical 0건** → `/pdca report 1.8` 진행 가능
+
+- CTO Lead 게이트: 매치율 ≥ 90% AND Critical 0건 → **호출 생략** (skill 규칙, 비용 절감)
+- 런타임 검증: 실제 DM 전송 E2E는 §6.1대로 **1.9 startup wiring 이월** (`dm-e2e-test-phase-sequence` 메모리 경계) → 본 analyze는 **정적 매치율로 종결**
+- archive 트리거 조건(매치율 ≥ 90%) 충족
+
+---
+
+*분석일: 2026-06-10*
+*참고: docs/phase-1-8/02-design.md*

--- a/docs/archive/phase-1-8/04-report.md
+++ b/docs/archive/phase-1-8/04-report.md
@@ -1,0 +1,157 @@
+# Phase 1.8 완료 보고서: Discord DM 발송 유틸리티
+
+**상태**: 🔍 검토 중
+**작성일**: 2026-06-10
+**PDCA 사이클**: plan → design → do → analyze → report
+
+---
+
+## 1. 요약
+
+### 1.1 개요
+| 항목 | 내용 |
+|------|------|
+| 기능명 | Discord DM 발송 유틸리티 |
+| Phase | 1.8 |
+| 시작일 | 2026-06-09 |
+| 완료일 | 2026-06-10 |
+| 최종 매치율 | 100% |
+| 반복 횟수 | 1회 (갭 0건, iterate 없음) |
+
+### 1.2 목표 달성
+
+| 목표 | 달성 | 비고 |
+|------|------|------|
+| `sendNotificationDM` 시그니처 포맷 무관 고정 (후속 4개 Phase 계약) | ✅ | `sendNotificationDM(userId, {embeds?,content?}): Promise<DmSendResult>` |
+| `sendNotificationDM` 구현 (재시도 3회 + 429 ms 대기 + 50007/10013 처리) | ✅ | 에러 코드별 분기 로직 완성 |
+| `notificationMessageEmbed` + `jobLink` 헬퍼 | ✅ | 공고 포맷 통합, 링크 DRY 추출 |
+| `NOTIFICATION_SEND` 핸들러 → DM → `NOTIFICATION_SENT` 발행 | ✅ | EventBus 패턴 1.7 대칭 |
+| `registerEventHandlers` 등록 연결 (startup 호출은 1.9) | ✅ | 1.9 경계 준수 |
+| `providers/CLAUDE.md` 드리프트 정정 | ✅ | embeds 기반 + `providerLogger` |
+| TypeScript 컴파일 성공 (baseline 외 새 에러 0건) | ✅ | tsc 통과 |
+| 기존 기능(recruitMessageEmbed) 정상 동작 | ✅ | 순수 추출, 출력 동일 |
+
+---
+
+## 2. 구현 요약
+
+### 2.1 주요 변경사항
+
+1. **`sendNotificationDM` 전송기** — Discord API rate limit·에러 처리 통합
+   - 최대 3회 재시도, rate limit은 **ms 단위 대기**(`*1000` 보정 없음)
+   - 50007(DM 차단) graceful skip, 10013(Unknown User) 실패, default 미지 코드 재시도 후 실패
+   - 결과를 `DmSendResult`로 반환(성공/skip/실패 구분), throw 없이 흡수(graceful degradation)
+   - `providerLogger` 성공(info)/skip(warn)/실패(error) 기록
+
+2. **임베드 빌더 통합** — 알림 전용 및 공용 헬퍼
+   - `notificationMessageEmbed(jobs)`: "🔔 새로운 채용 공고", **상위 3개 + 외 N건**
+   - `jobLink.ts`: `extractJobId`/`formatJobTitleLink` 공용 헬퍼 (recruitMessageEmbed 동일 동작 유지)
+
+3. **이벤트 핸들러** — NOTIFICATION_SEND 소비 → DM → NOTIFICATION_SENT 발행
+   - 1.7 try-catch/재throw 금지 패턴 대칭, `globalLogger`
+
+4. **등록 연결** — `registerEventHandlers`에 1줄 추가
+   - startup 호출·client 로그인은 1.9 위임 (경계 준수)
+
+### 2.2 파일 변경 목록
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `providers/discord/utils/dmSender.ts` | 신규 | `sendNotificationDM` + `DmSendResult`/`DmPayload` |
+| `providers/discord/builder/embeds/notificationMessageEmbed.ts` | 신규 | 알림 전용 임베드 빌더 |
+| `providers/discord/builder/embeds/jobLink.ts` | 신규 | 링크 추출/포맷 공용 헬퍼 |
+| `providers/discord/builder/embeds/recruitMessageEmbed.ts` | 수정 | private `extractJobId` 제거 → `jobLink` import |
+| `events/bus/handlers/NotificationSendHandler.ts` | 신규 | NOTIFICATION_SEND 소비 핸들러 |
+| `events/bus/utils/registerEventHandlers.ts` | 수정 | 핸들러 등록 1줄 추가 |
+| `providers/CLAUDE.md` | 수정 | dmSender 예시 드리프트 정정 |
+
+**총 산출물**: 7파일 (신규 5 + 수정 2)
+
+---
+
+## 3. 갭 분석 이력
+
+### 3.1 분석 결과 요약
+
+| 분석 회차 | 매치율 | 갭 수 | Critical | 조치 |
+|----------|--------|-------|---------|------|
+| 1차 (최종) | 100% | 0건 | 0건 | report 진행 |
+
+**상세 매치율**: Structural 8/8(100%) · Functional 13/13(100%) · Contract 11/11(100%)
+
+### 3.2 코드 품질 (Code Analyzer)
+
+| 심각도 | 개수 | 내용 |
+|--------|------|------|
+| 🔴 Critical | 0건 | — |
+| 🟡 Warning | 2건 | W1: notificationMessageEmbed ↔ recruitMessageEmbed 필드 포맷 잔여 중복(강제 통합 비권장); W2: recruitMessageEmbed 필드라인 들여쓰기(기존 코드, 1.8 범위 밖) |
+| 🟢 Info | 3건 | 관찰 용도 |
+
+**핵심 확정 사항** (의도된 설계):
+- **I-2**: rate limit 단위 = ms (discord.js 14.17.3 타입 정의 직접 검증, design pseudo-code `*1000` 버그 발견 → design.md 정정). RateLimitError는 `code` 없음 → `getRateLimitWaitMs` fallback.
+- **I-3**: `NotificationSentEvent` 타입 변경 없음 (skip은 success=false + error 미부여, 관측은 `providerLogger.warn` — 이벤트 계약 보존, YAGNI)
+- **I-4**: 상위 3개 + 외 N건 (notificationMessageEmbed)
+- 에러 분류: `error.code` switch (50007 skip→warn / 10013 실패→error / rate limit 재시도 / default 미지 코드 재시도 후 error)
+
+---
+
+## 4. 검토 사항
+
+**참고 문서**: [review-process.md](../../.claude/rules/review-process.md)
+
+> ⚠️ 피드백 수신 시 즉시 반영하지 않음 → 수정 계획 제시 → 사용자 승인 → 진행
+
+### 4.1 코드 리뷰
+- [x] 핵심 로직 구현 확인 (설계 §2.1~§2.6 모두 일치)
+- [x] 타입 안전성 확인 (tsc 통과, strict 준수)
+- [x] 에러 처리 확인 (50007/10013/rate limit/미지 코드 분기)
+
+### 4.2 기능 테스트
+- [x] TypeScript 컴파일 성공 (baseline 외 새 에러 0건)
+- [x] 기존 기능 정상 동작 (recruitMessageEmbed 순수 추출, 출력 동일)
+- [ ] **실제 DM 전송 E2E** ← **1.9 startup wiring 이월** (메모리: `dm-e2e-test-phase-sequence`, `phase-1-8-deferred-to-1-9`)
+
+### 4.3 문서화
+- [x] JSDoc 주석 확인 (모든 public 함수 한국어 주석)
+- [x] 관련 문서 업데이트 (`providers/CLAUDE.md` 드리프트 정정, `02-design.md` rate limit 단위 정정)
+
+---
+
+## 5. 피드백 반영 내역
+
+<!-- 리뷰 대기 중 — 피드백 수신 시 기록 -->
+
+---
+
+## 6. Process Improvement
+
+### 6.1 잘된 점
+- **시그니처 우선 고정**: 후속 4개 Phase 계약을 design 단계에서 선언 → Discord/Integration 병렬 작업 전제 확보
+- **do 단계 실타입 검증이 설계 버그 발견**: I-2에서 discord.js 14.17.3 타입 확인으로 design pseudo-code의 ms/초 단위 버그를 조기 교정
+- **경계 준수**: 1.9 startup/client.login 미추가로 단계별 책임 분명, 런타임 E2E 명시적 이월(메모리 기록)
+
+### 6.2 개선할 점
+- **Warning 잔여**: W1(필드 포맷 중복)은 입력 타입(`Job` vs `RecruitData`) 차이로 강제 통합 비권장 → 차기 리팩터링 시 타입 추상화 검토. W2(들여쓰기)는 기존 코드라 회귀 위험으로 1.8에서 미수정.
+
+### 6.3 다음 Phase 제안 / 이월 사항
+
+| 제안 | 관련 Phase | 우선순위 | 상태 |
+|------|-----------|---------|------|
+| 런타임 E2E (실제 DM 전송·50007 skip·rate limit 검증) | 1.9 | P0 | 메모리 `phase-1-8-deferred-to-1-9` 기록 |
+| Warning W1/W2 (필드 포맷 DRY·들여쓰기) | 1.9 또는 차기 리팩터링 | P2 | 강제 통합 회피(회귀 위험), recruitMessageEmbed 수정 시 동반 정리 |
+
+---
+
+## 7. 다음 단계
+
+1. [ ] 사용자 피드백 확인 및 승인
+2. [ ] `/pdca archive 1.8` 실행 (문서 아카이브)
+3. [ ] `/pdca cleanup` 실행 (status JSON 정리 + memory 초기화)
+4. [ ] Git 커밋(논리 단위) + push + PR 생성 (base dev) — archive/cleanup 변경 포함
+5. [ ] PR 머지 → dev 동기화 → `/pdca next`
+
+---
+
+*작성일: 2026-06-10*
+*참고: 01-plan.md, 02-design.md, 03-analysis.md*
+*메모리: `dm-e2e-test-phase-sequence` (1.9 E2E 경계), `phase-1-8-deferred-to-1-9` (후속 작업 추적)*

--- a/functions/src/events/bus/handlers/NotificationSendHandler.ts
+++ b/functions/src/events/bus/handlers/NotificationSendHandler.ts
@@ -1,0 +1,47 @@
+import "@/common/utils/systemLogger"; // globalLogger 전역 등록
+import { eventBus, EventType } from "@/events/bus";
+import type { NotificationSendEvent, NotificationSentEvent } from "@/events/bus";
+import { notificationMessageEmbed } from "@/providers/discord/builder/embeds/notificationMessageEmbed";
+import { sendNotificationDM } from "@/providers/discord/utils/dmSender";
+
+/**
+ * 알림 발송 핸들러 등록 (Phase 1.8)
+ *
+ * `NOTIFICATION_SEND` → 임베드 빌드 → `sendNotificationDM` → `NOTIFICATION_SENT` 발행.
+ *
+ * @remarks 1.7 `NotificationEventHandler` 패턴과 대칭 — 핸들러 내부 try-catch로
+ *   EventBus 안정성을 확보한다(emitter로 재throw 금지). `dmSender`는 이미 graceful하게
+ *   `DmSendResult`를 반환하므로 try-catch는 빌더 예외 등에 대한 2차 안전망이다.
+ *   `registerAllEventHandlers()` 자체의 startup 호출은 Phase 1.9에 위임.
+ */
+export function registerNotificationSendHandlers(): void {
+  eventBus.onEvent<NotificationSendEvent>(EventType.NOTIFICATION_SEND, async (payload) => {
+    try {
+      if (payload.jobs.length === 0) return;
+
+      const embed = notificationMessageEmbed(payload.jobs);
+      const result = await sendNotificationDM(payload.userId, { embeds: [embed] });
+
+      // skip(DM 차단)도 success=false로 발행 — 1.9+ 소비자가 결과를 관찰한다.
+      // 성공/skip/실패 구분은 dmSender가 providerLogger로 이미 기록하므로
+      // SentEvent에는 추가 필드를 만들지 않는다(I-3: types.ts 계약 변경 없음).
+      eventBus.emitEvent<NotificationSentEvent>(EventType.NOTIFICATION_SENT, {
+        timestamp: Date.now(),
+        source: "NotificationSendHandler",
+        userId: payload.userId,
+        jobCount: payload.jobs.length,
+        success: result.ok,
+        // skip은 정상 상태이므로 error 미부여. 진짜 실패(ok=false && !skipped)일 때만 부여.
+        ...(!result.ok && !result.skipped
+          ? { error: new Error(result.reason ?? "DM 전송 실패") }
+          : {}),
+      });
+    } catch (error) {
+      // emitter 안정성 — 재throw 금지(1.7 패턴 동일).
+      globalLogger.error("알림 발송 핸들러 처리 실패", error as Error, {
+        event: EventType.NOTIFICATION_SEND,
+        source: "NotificationSendHandler",
+      });
+    }
+  });
+}

--- a/functions/src/events/bus/utils/registerEventHandlers.ts
+++ b/functions/src/events/bus/utils/registerEventHandlers.ts
@@ -8,6 +8,7 @@
 import { eventBus } from '../EventBus';
 import { eventLogger } from './eventLogger';
 import { registerNotificationHandlers } from '../handlers/NotificationEventHandler';
+import { registerNotificationSendHandlers } from '../handlers/NotificationSendHandler';
 
 /**
  * 핸들러 등록 상태 추적
@@ -48,6 +49,10 @@ export function registerAllEventHandlers(): void {
   // Phase 1.7: NotificationService 핸들러
   // 등록만 연결 — registerAllEventHandlers() 자체의 startup 호출은 Phase 1.9 위임
   registerNotificationHandlers();
+
+  // Phase 1.8: NOTIFICATION_SEND 소비 핸들러 (DM 발송)
+  // 등록만 연결 — startup 호출·client 로그인은 Phase 1.9 위임
+  registerNotificationSendHandlers();
 
   // Phase 1.10: ProxyErrorHandler 핸들러 (TODO)
   // registerProxyErrorHandlers();

--- a/functions/src/providers/claude.md
+++ b/functions/src/providers/claude.md
@@ -38,75 +38,57 @@ providers/
 
 ## discord/utils/ (NEW - Phase 1.8)
 
-### dmSender.ts
-**역할**: Discord DM 발송, Rate Limit 처리
+### dmSender.ts (Phase 1.8 확정 계약)
+**역할**: Discord DM 발송, Rate Limit·차단 처리 (graceful degradation)
+
+> **구현 SoT**: `providers/discord/utils/dmSender.ts`
+> **계약**: 시그니처는 **embeds 기반 포맷 무관**(format-agnostic) — 후속 4개 Phase(1.9/1.10/2.1/2.2)의 공유 계약이므로 `title/recruits` 같은 포맷을 시그니처에 박지 않는다.
 
 ```typescript
-import { Client } from 'discord.js';
+import type { MessageCreateOptions } from "discord.js";
+import { client } from "@/providers/discord/client";
+import { providerLogger } from "@/common/utils/systemLogger";
 
+export interface DmPayload {
+  embeds?: MessageCreateOptions["embeds"]; // 호출 측 빌더 산출물 (예: notificationMessageEmbed)
+  content?: string;
+}
+
+export interface DmSendResult {
+  ok: boolean;          // 전송 성공 여부 (skip도 ok=false)
+  skipped?: boolean;    // DM 차단(50007) 등 "보낼 수 없는 정상 상태"
+  reason?: string;      // "dm_disabled" | "unknown_user" | "max_retries"
+  errorCode?: number;   // Discord API 에러 코드 (기록용)
+  durationMs: number;
+  attempts: number;
+}
+
+// 포맷 무관 — 임베드는 호출 측(이벤트 핸들러)이 빌더로 완성해 전달.
+// provider 계층은 throw 금지 — 모든 결과를 DmSendResult로 흡수 반환.
 export async function sendNotificationDM(
   userId: string,
-  options: {
-    title: string;
-    description?: string;
-    recruits?: RecruitData[];
-    color?: number;
-  }
-): Promise<void> {
-  const client = getDiscordClient();
-
-  try {
-    const user = await client.users.fetch(userId);
-
-    const embed = {
-      title: options.title,
-      description: options.description || '',
-      color: options.color || 0x5865F2,
-      fields: options.recruits?.map(r => ({
-        name: r.title,
-        value: `지역: ${r.region}\n기간: ${r.startDate} ~ ${r.endDate}`,
-        inline: false
-      })) || [],
-      timestamp: new Date().toISOString()
-    };
-
-    await user.send({ embeds: [embed] });
-
-    console.log(`[dmSender] DM sent to ${userId}`);
-
-  } catch (error) {
-    if (error.code === 50007) {
-      console.error(`[dmSender] User ${userId} has DMs disabled`);
-    } else {
-      console.error(`[dmSender] Failed to send DM to ${userId}:`, error);
-      throw error;
-    }
-  }
-}
-
-// Rate Limit 처리 (Discord: 5 req/5s per user)
-export async function sendBulkNotifications(
-  userIds: string[],
-  options: any
-): Promise<{ sent: number; failed: number }> {
-  let sent = 0;
-  let failed = 0;
-
-  for (const userId of userIds) {
-    try {
-      await sendNotificationDM(userId, options);
-      sent++;
-
-      // Rate Limit 대기 (1초)
-      await new Promise(resolve => setTimeout(resolve, 1000));
-    } catch (error) {
-      failed++;
-    }
-  }
-
-  return { sent, failed };
-}
+  payload: DmPayload
+): Promise<DmSendResult>;
 ```
+
+**에러 분류** (`error.code` switch + RateLimitError 방어):
+
+| 코드/유형 | 처리 | 재시도 | 로깅 |
+|-----------|------|--------|------|
+| `50007` (DM 차단/공유 길드 없음) | graceful skip `{ ok:false, skipped:true, reason:"dm_disabled" }` | ❌ | `providerLogger.warn` |
+| `10013` (Unknown User) | 실패 `{ ok:false, reason:"unknown_user" }` | ❌ | `providerLogger.error` |
+| 429 / `RateLimitError` | 대기 후 재시도 | ✅ | `providerLogger.warn` |
+| 그 외 미지 코드 | 짧은 backoff 후 재시도, 소진 시 `{ ok:false, reason:"max_retries" }` | ✅ (최대 3회) | `providerLogger.error` |
+| 성공 | `{ ok:true }` | — | `providerLogger.info` |
+
+**discord.js 14.17 rate limit 단위 (중요)**:
+- 기본 설정(`rejectOnRateLimit: null`)에서 discord.js REST는 rate limit을 **내부 큐로 흡수·대기**하므로 보통 `RateLimitError`를 throw하지 않는다(내부 `retries: 3` 포함).
+- 방어적으로 `RateLimitError`를 받을 경우 `retryAfter`/`timeToReset`는 **밀리초(ms)** 단위다 — 원시 HTTP의 `retry_after`(초)와 다르므로 **`*1000` 보정 금지**.
+- 구독자 간 발송 간격은 v14 REST 내장 큐에 위임한다. `setTimeout` 기반 순차 발송 헬퍼(`sendBulkNotifications`)는 본 Phase 범위가 아니며, 순차 발송 블로킹 비용은 Phase 1.9 E2E에서 실측한다.
+
+**금지 사항**:
+- `console.log`/`console.error` 금지 → 성공(info)/skip(warn)/실패(error) 모두 `providerLogger`(LogSource `provider`).
+- provider 계층은 services/features 참조 금지.
 
 ---
 

--- a/functions/src/providers/discord/builder/embeds/jobLink.ts
+++ b/functions/src/providers/discord/builder/embeds/jobLink.ts
@@ -1,0 +1,37 @@
+/**
+ * 공고 링크 공용 헬퍼 (DRY 추출)
+ *
+ * recruitMessageEmbed / notificationMessageEmbed가 공유하는 순수 함수.
+ * 기존 recruitMessageEmbed의 인라인 표현을 동작 변경 없이 캡슐화한다.
+ */
+
+/**
+ * href("/jobs/12345")에서 jobId("12345")를 추출한다.
+ *
+ * @param path 공고 상세 경로 (예: "/jobs/12345")
+ * @returns 추출된 jobId 문자열. 매치 실패 시 빈 문자열("").
+ * @example extractJobId("/jobs/12345") // "12345"
+ */
+export function extractJobId(path: string): string {
+  const match = path.match(/\/jobs\/(\d+)/);
+  return match ? match[1] : "";
+}
+
+/**
+ * 공고 제목을 마크다운 링크로 포맷한다.
+ *
+ * baseUrl이 없으면 링크 없이 제목만 반환한다
+ * (기존 recruitMessageEmbed의 baseUrl 분기 동작과 동일).
+ *
+ * @param title 공고 제목
+ * @param href 공고 상세 경로 (예: "/jobs/12345")
+ * @param baseUrl 공고 페이지 base URL (없으면 링크 미생성)
+ * @returns `[title](baseUrl{jobId})` 또는 title
+ */
+export function formatJobTitleLink(
+  title: string,
+  href: string,
+  baseUrl?: string
+): string {
+  return baseUrl ? `[${title}](${baseUrl}${extractJobId(href)})` : title;
+}

--- a/functions/src/providers/discord/builder/embeds/notificationMessageEmbed.ts
+++ b/functions/src/providers/discord/builder/embeds/notificationMessageEmbed.ts
@@ -1,0 +1,47 @@
+import { APIEmbed, EmbedBuilder } from "discord.js";
+import type { Job } from "@/common/types/job.d";
+import { ENV } from "@/common/utils";
+import { formatJobTitleLink } from "./jobLink";
+
+/** 알림 임베드에 필드로 직접 표시할 상위 공고 개수. */
+const TOP_COUNT = 3;
+/** "외 N건 더 있습니다" 요약 줄을 추가하는 임계 공고 수. */
+const OVERFLOW_THRESHOLD = 6;
+
+/**
+ * 새 공고 알림 DM용 임베드를 생성한다.
+ *
+ * "🔔 새로운 채용 공고" 헤더 + 상위 3개 공고를 필드로 표시한다.
+ * 공고가 6건 이상이면 마지막에 "외 N건 더 있습니다" 한 줄을 덧붙인다(I-4).
+ * Discord 25필드/6000자 한계는 상위 3개만 표시하므로 자연 충족한다.
+ *
+ * @param jobs 새로 등록된 공고 목록 (이벤트 페이로드의 `Job[]`)
+ * @returns 알림용 임베드 JSON
+ */
+export function notificationMessageEmbed(jobs: Job[]): APIEmbed {
+  const baseUrl = ENV.SRIA_URL;
+
+  const embed = new EmbedBuilder()
+    .setTitle("🔔 새로운 채용 공고")
+    .setDescription(`총 ${jobs.length}건의 새로운 공고가 등록되었어요.`)
+    .setColor(0x00b0f4)
+    .setTimestamp();
+
+  jobs.slice(0, TOP_COUNT).forEach((job, index) => {
+    const r = job.value; // Job.value: RecruitData
+    const titleLine = formatJobTitleLink(r.title, r.href, baseUrl);
+    embed.addFields({
+      name: "\n",
+      value: `${index + 1}. ${titleLine}\n📅 ${r.dayTxt} | ⏱ ${r.dDay} | 🏷️ 상태: ${r.recruitmentStatus}`,
+    });
+  });
+
+  if (jobs.length >= OVERFLOW_THRESHOLD) {
+    embed.addFields({
+      name: "\n",
+      value: `외 ${jobs.length - TOP_COUNT}건 더 있습니다.`,
+    });
+  }
+
+  return embed.toJSON();
+}

--- a/functions/src/providers/discord/builder/embeds/recruitMessageEmbed.ts
+++ b/functions/src/providers/discord/builder/embeds/recruitMessageEmbed.ts
@@ -1,11 +1,7 @@
 import { APIEmbed, EmbedBuilder } from "discord.js";
 import type { RecruitData } from "@/crawlers/types";
 import { ENV } from "@/common/utils";
-
-function extractJobId(path: string) {
-  const match = path.match(/\/jobs\/(\d+)/);
-  return match ? match[1] : "";
-}
+import { formatJobTitleLink } from "./jobLink";
 
 export function recruitMessageEmbed(list: RecruitData[], region?: string): APIEmbed {
   const baseUrl = ENV.SRIA_URL;
@@ -25,9 +21,7 @@ export function recruitMessageEmbed(list: RecruitData[], region?: string): APIEm
     .setTimestamp();
 
   list.slice(0, topCount).forEach((item, index) => {
-    const titleLine = baseUrl
-      ? `[${item.title}](${baseUrl}${extractJobId(item.href)})`
-      : item.title;
+    const titleLine = formatJobTitleLink(item.title, item.href, baseUrl);
     embed
       .addFields({
         name: `\n`,

--- a/functions/src/providers/discord/utils/dmSender.ts
+++ b/functions/src/providers/discord/utils/dmSender.ts
@@ -1,0 +1,197 @@
+import type { MessageCreateOptions } from "discord.js";
+import { client } from "@/providers/discord/client";
+import { providerLogger } from "@/common/utils/systemLogger";
+
+/**
+ * DM 발송 페이로드 — 포맷 무관(format-agnostic).
+ *
+ * 호출 측(이벤트 핸들러)이 빌더로 완성한 embeds/content를 그대로 전달한다.
+ * 포맷(title/recruits 등)을 시그니처에 박지 않는다 — 후속 4개 Phase(1.9/1.10/2.1/2.2)의 계약.
+ */
+export interface DmPayload {
+  /** 완성된 임베드 배열 (호출 측 빌더 산출물, 예: notificationMessageEmbed). */
+  embeds?: MessageCreateOptions["embeds"];
+  /** 임베드 대신/병행할 평문 메시지. */
+  content?: string;
+}
+
+/**
+ * DM 발송 결과 — 성공 / graceful skip / 실패 3분기.
+ *
+ * 호출 측(핸들러)이 NOTIFICATION_SENT 발행 여부·success 플래그를 판정하는 데 사용한다.
+ */
+export interface DmSendResult {
+  /** 전송 성공 여부. skip(=차단)도 ok=false, skipped=true로 구분. */
+  ok: boolean;
+  /** DM 차단/공유 길드 없음(50007) 등 "보낼 수 없는 정상 상태" → 재시도·에러 아님. */
+  skipped?: boolean;
+  /** ok=false일 때 사유 코드/요약 ("dm_disabled" | "unknown_user" | "max_retries"). */
+  reason?: string;
+  /** Discord API 에러 코드 (50007 / 10013 등), 있으면 기록용. */
+  errorCode?: number;
+  /** 총 소요 시간(ms) — 로깅·관찰용. */
+  durationMs: number;
+  /** 실제 시도 횟수. */
+  attempts: number;
+}
+
+/** 최대 시도 횟수 (최초 1 + 재시도 2). */
+const MAX_ATTEMPTS = 3;
+/** 일시 오류 시 짧은 backoff 기준(ms). */
+const BASE_BACKOFF_MS = 500;
+/** DM 차단 / 공유 길드 없음 → graceful skip. */
+const ERR_DM_DISABLED = 50007;
+/** Unknown User → 재시도 없이 실패. */
+const ERR_UNKNOWN_USER = 10013;
+/** rate limit 대기값이 없을 때의 기본 대기(ms). */
+const FALLBACK_RATE_LIMIT_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * discord.js 14.17 에러에서 수치 코드만 추출한다.
+ *
+ * `DiscordAPIError.code`는 `number | string`이므로 number일 때만 반환한다.
+ * RateLimitError는 `code`가 없어 undefined가 된다.
+ */
+function getErrorCode(error: unknown): number | undefined {
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "number" ? code : undefined;
+}
+
+/**
+ * rate limit 대기 시간(ms)을 추출한다.
+ *
+ * discord.js 14.17의 RateLimitError는 `retryAfter`/`timeToReset`을 **밀리초**로 제공한다
+ * (초 아님 — `*1000` 보정 금지). DiscordAPIError.status === 429인 경우도 방어적으로 처리한다.
+ *
+ * @returns rate limit 대기(ms). rate limit이 아니면 undefined.
+ */
+function getRateLimitWaitMs(error: unknown): number | undefined {
+  const e = error as {
+    retryAfter?: number;
+    timeToReset?: number;
+    status?: number;
+    name?: string;
+  };
+
+  // RateLimitError: retryAfter / timeToReset 둘 다 ms 단위.
+  if (typeof e.retryAfter === "number") return e.retryAfter;
+  if (typeof e.timeToReset === "number") return e.timeToReset;
+
+  // DiscordAPIError 등에서 HTTP 429만 감지된 경우 — 대기값 미상 → fallback.
+  if (e.status === 429 || e.name === "RateLimitError") return FALLBACK_RATE_LIMIT_MS;
+
+  return undefined;
+}
+
+/**
+ * 지정한 사용자에게 알림 DM을 발송한다.
+ *
+ * 포맷 무관(embeds 기반) — 임베드는 호출 측이 빌더로 완성해 전달한다.
+ * providers 계층 규칙에 따라 예외를 throw하지 않고 모든 결과를 {@link DmSendResult}로
+ * 흡수해 반환한다(graceful degradation). 조율(이벤트 발행 등)은 호출 측이 결과로 판단한다.
+ *
+ * 에러 분류:
+ * - 50007 (DM 차단/공유 길드 없음) → 재시도 없이 graceful skip
+ * - 10013 (Unknown User) → 재시도 없이 실패
+ * - 429 / RateLimitError → 대기(ms, *1000 금지) 후 재시도
+ * - 그 외 미지 코드 → 짧은 backoff 후 재시도, 소진 시 실패
+ *
+ * @param userId 대상 Discord 사용자 ID
+ * @param payload 발송할 embeds/content (포맷 무관)
+ * @returns 발송 결과 (성공/skip/실패 + 소요시간·시도횟수)
+ */
+export async function sendNotificationDM(
+  userId: string,
+  payload: DmPayload
+): Promise<DmSendResult> {
+  const startedAt = Date.now();
+  let attempts = 0;
+
+  while (attempts < MAX_ATTEMPTS) {
+    attempts++;
+    try {
+      const user = await client.users.fetch(userId);
+      await user.send({ embeds: payload.embeds, content: payload.content });
+
+      const durationMs = Date.now() - startedAt;
+      providerLogger.info("DM 발송 성공", { userId, durationMs, attempts });
+      return { ok: true, durationMs, attempts };
+    } catch (error) {
+      const code = getErrorCode(error);
+
+      // (1) DM 차단 / 공유 길드 없음 → 재시도 없이 graceful skip.
+      if (code === ERR_DM_DISABLED) {
+        const durationMs = Date.now() - startedAt;
+        providerLogger.warn("DM 차단 skip (DM 차단/공유 길드 없음)", {
+          userId,
+          errorCode: code,
+          durationMs,
+          attempts,
+        });
+        return {
+          ok: false,
+          skipped: true,
+          reason: "dm_disabled",
+          errorCode: code,
+          durationMs,
+          attempts,
+        };
+      }
+
+      // (2) Unknown User → 재시도 없이 실패.
+      if (code === ERR_UNKNOWN_USER) {
+        const durationMs = Date.now() - startedAt;
+        providerLogger.error("DM 발송 실패 (Unknown User)", error as Error, {
+          userId,
+          errorCode: code,
+          durationMs,
+          attempts,
+        });
+        return {
+          ok: false,
+          reason: "unknown_user",
+          errorCode: code,
+          durationMs,
+          attempts,
+        };
+      }
+
+      // (3) Rate limit → 대기(ms, *1000 금지) 후 재시도.
+      const rateLimitWaitMs = getRateLimitWaitMs(error);
+      if (rateLimitWaitMs != null) {
+        if (attempts >= MAX_ATTEMPTS) break;
+        providerLogger.warn("DM 발송 rate limit — 대기 후 재시도", {
+          userId,
+          waitMs: rateLimitWaitMs,
+          attempts,
+        });
+        await sleep(rateLimitWaitMs);
+        continue;
+      }
+
+      // (4) 그 외 미지 코드 → 일시 오류로 보고 짧은 backoff 후 재시도.
+      if (attempts >= MAX_ATTEMPTS) break;
+      providerLogger.warn("DM 발송 일시 오류 — backoff 후 재시도", {
+        userId,
+        errorCode: code,
+        attempts,
+      });
+      await sleep(BASE_BACKOFF_MS * attempts);
+      continue;
+    }
+  }
+
+  // 재시도 소진 → 실패.
+  const durationMs = Date.now() - startedAt;
+  providerLogger.error("DM 발송 실패 (재시도 소진)", undefined, {
+    userId,
+    reason: "max_retries",
+    durationMs,
+    attempts,
+  });
+  return { ok: false, reason: "max_retries", durationMs, attempts };
+}


### PR DESCRIPTION
## Summary

`NOTIFICATION_SEND` 이벤트를 실제 Discord DM 전송으로 연결하는 Phase 1.8. 알림 파이프라인의 마지막 전송 계층을 구현하고, `sendNotificationDM` 시그니처를 후속 Phase 계약으로 격상했다.

## 주요 변경사항

- **dmSender**: embeds 기반 포맷 무관 전송기 — 재시도 3회 + 429 `retry_after` 준수 + 50007(DM 차단) graceful skip
- **notificationMessageEmbed**: 알림 임베드 빌더
- **jobLink**: 채용 링크 공용 헬퍼 (recruitMessageEmbed와 DRY 공유)
- **NotificationSendHandler**: `NOTIFICATION_SEND` 소비 → DM 전송 → `NOTIFICATION_SENT` 발행
- **registerEventHandlers**: 핸들러 등록 연결

## 기술적 개선사항

- `sendNotificationDM` 시그니처를 후속 Phase(1.9/1.10/2.1/2.2) 계약으로 격상
- Discord API 에러(50007/429) graceful 처리로 전송 실패가 파이프라인을 막지 않음
- jobLink 추출로 recruit/notification 임베드 간 링크 생성 로직 중복 제거

## 테스트 상태

- ✅ 정적 분석(analyze) 매치율 100%, 🔴 Critical 0건
- ✅ `tsc --noEmit` 통과
- ⏸️ 런타임 E2E(실제 DM 전송)는 startup·client 로그인 wiring이 필요하여 **Phase 1.9로 위임**

## Breaking Changes

없음 (신규 전송 계층 추가, 기존 인터페이스 변경 없음)

Ref: pdca-status.json Phase 1.8