### PR TITLE
Phase 1.13: 프로덕션 런타임 & 스케줄러 트리거 재설계

### DIFF
--- a/.claude/docs/pdca-status.json
+++ b/.claude/docs/pdca-status.json
@@ -1,10 +1,10 @@
 {
   "overview": {
-    "total": 26,
-    "completed": 11,
+    "total": 27,
+    "completed": 12,
     "phases": {
-      "phase-1": { "completed": 11, "total": 13, "progress": "85%" },
-      "phase-2": { "completed": 0, "total": 2, "progress": "0%" },
+      "phase-1": { "completed": 12, "total": 13, "progress": "92%" },
+      "phase-2": { "completed": 0, "total": 3, "progress": "0%" },
       "phase-3": { "completed": 0, "total": 5, "progress": "0%" },
       "phase-4": { "completed": 0, "total": 6, "progress": "0%" }
     }
@@ -21,6 +21,7 @@
     "P1": [
       "phase-1-6-recruit-request-enhancement", "phase-1-11-debuglogger-migration",
       "phase-2-1-auto-error-reporting", "phase-2-2-admin-broadcast",
+      "phase-2-3-user-feedback",
       "phase-3-1-test-framework-setup",
       "phase-4-1-ai-provider-setup", "phase-4-2-ai-nlp-cache",
       "phase-4-3-ai-nlp-service", "phase-4-4-discord-nlp-integration"
@@ -47,6 +48,7 @@
     "phase-1-13-production-runtime": ["phase-1-9-scheduler-reactivation"],
     "phase-2-1-auto-error-reporting": ["phase-1-1-eventbus-infrastructure", "phase-1-8-discord-dm-utility", "phase-1-13-production-runtime"],
     "phase-2-2-admin-broadcast": ["phase-1-4-notification-store", "phase-1-8-discord-dm-utility", "phase-1-13-production-runtime"],
+    "phase-2-3-user-feedback": ["phase-1-8-discord-dm-utility", "phase-1-13-production-runtime"],
     "phase-3-1-test-framework-setup": [],
     "phase-3-2-unit-tests": ["phase-3-1-test-framework-setup"],
     "phase-3-3-integration-tests": ["phase-3-1-test-framework-setup"],
@@ -73,11 +75,12 @@
       { "features": "phase-1-8-discord-dm-utility", "phase": "archived", "matchRate": 100.0, "description": "NOTIFICATION_SEND → 실제 Discord DM 전송 연결. dmSender(embeds 기반 포맷 무관 전송기, 재시도 3회+429 retry_after+50007 graceful skip) + 알림 임베드 빌더 + jobLink 공용 헬퍼(DRY) + NOTIFICATION_SEND 소비 핸들러(→NOTIFICATION_SENT 발행) + registerEventHandlers 등록 연결. sendNotificationDM 시그니처를 후속 Phase(1.9/1.10/2.1/2.2) 계약으로 격상. startup·client 로그인·E2E는 1.9 위임", "startedAt": "2026-06-09", "completedAt": "2026-06-10", "documents": { "plan": "docs/archive/phase-1-8/01-plan.md", "design": "docs/archive/phase-1-8/02-design.md", "analysis": "docs/archive/phase-1-8/03-analysis.md", "report": "docs/archive/phase-1-8/04-report.md" } },
       { "features": "phase-1-9-scheduler-reactivation", "phase": "archived", "matchRate": 100.0, "description": "알림 파이프라인 startup wiring(핸들러 등록·DUMMY 스케줄러·ready 게이트 C안·env rename) + 로컬 DUMMY E2E(실 DM 수신) + 알림 임베드 UX 개편(iterate #1: 배너 content 2줄·description 목록·오버플로 링크·SELECTED 안내문·ALL 분기). R4/R5·DM 에러분기·부하·로그 수집은 Phase 1.13 이월", "startedAt": "2026-06-11", "completedAt": "2026-07-24", "documents": { "plan": "docs/archive/phase-1-9/01-plan.md", "design": "docs/archive/phase-1-9/02-design.md", "analysis": "docs/archive/phase-1-9/03-analysis.md", "report": "docs/archive/phase-1-9/04-report.md" } },
       { "features": "phase-1-10-proxy-integration", "phase": null, "matchRate": null, "documents": {} },
-      { "features": "phase-1-13-production-runtime", "phase": null, "matchRate": null, "documents": {} }
+      { "features": "phase-1-13-production-runtime", "phase": "archived", "matchRate": 100.0, "description": "프로덕션 런타임 & 스케줄러 트리거 재설계 — C안 하이브리드(인터랙션 gateway 상시 / 크롤·알림 serverless onSchedule). 진입점 분리 + setTimeout→onSchedule(runOnce 단일 tick) + dmSender REST 전환(계약 불변) + emitEventAndSettle 틱 완결 파이프라인 + crawlAndDiff 분리(Redis 분산 락). RECRUIT_NEW→RECRUIT_CHANGED 이벤트 리네임. 런타임검증 R1~R3(로컬 DUMMY)+diff 3케이스 PASS. R4(실 DM)·R5(실배포)·crawlService DUMMY 버그는 1.10 이월. 코드+정적/로컬 한정", "startedAt": "2026-08-04", "completedAt": "2026-08-07", "documents": { "plan": "docs/archive/phase-1-13/01-plan.md", "design": "docs/archive/phase-1-13/02-design.md", "analysis": "docs/archive/phase-1-13/03-analysis.md", "report": "docs/archive/phase-1-13/04-report.md" } }
     ],
     "phase-2": [
       { "features": "phase-2-1-auto-error-reporting", "phase": null, "matchRate": null, "documents": {} },
-      { "features": "phase-2-2-admin-broadcast", "phase": null, "matchRate": null, "documents": {} }
+      { "features": "phase-2-2-admin-broadcast", "phase": null, "matchRate": null, "documents": {} },
+      { "features": "phase-2-3-user-feedback", "phase": null, "matchRate": null, "documents": {} }
     ],
     "phase-3": [
       { "features": "phase-3-1-test-framework-setup", "phase": null, "matchRate": null, "documents": {} },

--- a/docs/archive/phase-1-13/01-plan.md
+++ b/docs/archive/phase-1-13/01-plan.md
@@ -1,0 +1,153 @@
+# Phase 1.13: 프로덕션 런타임 & 스케줄러 트리거 재설계
+
+**상태**: 🔄 진행 중
+**우선순위**: ⭐⭐⭐ (P0)
+**의존성**: Phase 1.9 완료 (archived, matchRate 100%)
+
+---
+
+## 개요
+
+### 배경
+
+현재 배포 타깃이 `onRequest` cold-start Cloud Functions라, 프로덕션에서 두 가지가 동작하지 않는다:
+
+- `BaseScheduler`의 in-process `setTimeout` 스케줄러(`BaseScheduler.ts:119-121`) → 응답 후 CPU 동결로 4시간 타이머가 발화하지 않는다.
+- 봇이 gateway WebSocket에 의존 → dmSender(`dmSender.ts:117/122` `getDiscordReady` + `client.users.fetch`)가 서버리스 틱과 비호환이다.
+
+또한 스케줄러가 사용자 요청용 3-tier 캐시 경로(`recruitService.getRecruitList`)를 호출해, TTL 없는 Firestore canonical doc이 항상 히트하면서 **실제 크롤(Step4)에 도달하지 못해 변경 감지가 무의미**해진다.
+
+Phase 1.9는 이 때문에 "로컬 검증 한정"으로 축소되었고(startup wiring + 로컬 DUMMY 스케줄러 + ready 게이트 + env rename + emulator DM E2E), 실 CRAWL·프로덕션 구동은 Phase 1.10으로 이월됐다.
+
+### 목표
+
+런타임을 재설계하여 서버리스 환경에서 크롤→diff→알림 파이프라인이 성립하도록 **코드까지 완성 + 로컬 검증**한다. 실배포·실 CRAWL 활성화·프로덕션 E2E는 Phase 1.10으로 이월한다.
+
+### 범위
+
+| 포함 | 제외 |
+|------|------|
+| §1 런타임 결정 (C안 하이브리드 확정) | 실배포 (gateway Cloud Run + 함수) → 1.10 |
+| 진입점 분리 (gateway / 함수 부트스트랩) — 코드 | 실 CRAWL 활성화 (`recruitMode: CRAWL`) → 1.10 |
+| `setTimeout` → `onSchedule` 전환 — 코드 (정적) | onSchedule 실발화 검증 → 1.10 |
+| dmSender gateway → REST 전용 (계약 불변) | REST 실전송·프로덕션 E2E → 1.10 |
+| 틱 완결 파이프라인 (크롤→diff→알림 await) | `crawlService.ts:28` DUMMY 버그(#6) → 1.10 이월 |
+| 스케줄러 전용 `crawlAndDiff(mode)` 분리 | 인터랙션 HTTP 전환 (C안은 gateway 유지 → 불필요) |
+| EventBus/durable 경계 방침 명시 (design §1) | durable bus(Firestore 트리거) 실제 배선 → 2.1/2.2 |
+
+---
+
+## 요구사항
+
+### 기능 요구사항
+
+1. **§1 런타임 결정 — C안 하이브리드 확정**: 인터랙션 수신은 gateway 상시 프로세스 유지, 크롤·알림은 serverless(onSchedule). design §1에 트레이드오프·비용·계약 영향을 고정한다.
+2. **진입점 분리**: `app/index.ts`를 gateway 부트스트랩 / 함수 부트스트랩으로 분리 — gateway는 스케줄러를 시작하지 않고, 함수는 gateway 연결을 열지 않는다(각자 필요한 것만 init).
+3. **스케줄러 트리거 전환**: `BaseScheduler`의 `setTimeout` 루프 → `onSchedule`(Cloud Scheduler) 코드로 전환. 실제 발화 검증은 Phase 1.10 배포에서.
+4. **dmSender REST 전환**: discord.js 클라이언트(gateway) 의존 → REST 전용. `DmPayload`/`DmSendResult` 계약 불변 유지 (1.9/1.10/2.1/2.2 공유 계약). `getDiscordReady` gateway 게이트 제거는 계약 외 내부 변경으로만.
+5. **틱 완결 파이프라인**: 한 번의 스케줄 실행이 크롤→diff→알림까지 await 완결되도록 보장 (EventBus #2 내부 완결).
+6. **스케줄러 크롤 경로 재설계 — `crawlAndDiff(mode)` 분리**: Redis/Firestore 읽기 우회 → 강제 크롤 → `setRecruitList` diff(Redis hash 기준) → `RECRUIT_NEW`. 사용자 요청 경로(`getRecruitList` 3-tier)는 보존(회귀 방지).
+
+### 비기능 요구사항
+
+- **성능**: 틱 완결 파이프라인의 순차 발송 블로킹 비용은 인지만 하고 실측은 1.10 E2E로 이월.
+- **호환성**: `DmPayload`/`DmSendResult` 계약 불변. `getRecruitList` 3-tier 경로 무회귀. 인터랙션 수신 코드 무변경.
+- **에러 처리**: SystemError 패턴 준수. dmSender는 providers 계층 규칙대로 throw 금지·결과 흡수 반환.
+
+---
+
+## 기술 스택 (프로젝트 고정)
+
+| 항목 | 기술 |
+|------|------|
+| Runtime | Firebase Functions (Node.js) + gateway 상시 프로세스(Cloud Run min-instance, 배포는 1.10) |
+| Language | TypeScript (strict mode) |
+| Database | Firestore |
+| Messaging | discord.js (gateway=인터랙션 수신 / REST=DM 발송) |
+| Event System | EventBus (Singleton, 프로세스-로컬) + durable bus(Firestore 트리거, 2.1/2.2 배선) |
+| Scheduler | onSchedule (Cloud Scheduler) |
+| Error Handling | SystemError + errorHandler |
+| Logging | SystemLogger |
+
+---
+
+## 구현 전략
+
+### 접근 방식 — C안 하이브리드
+
+```
+① Gateway 프로세스 (상시·slim)          ② Serverless 함수 (scale-to-zero)
+   ├─ discord.js Client (WebSocket)         ├─ onSchedule (4h) → crawlAndDiff
+   ├─ onInteraction (슬래시/버튼/모달)       │    └─ RECRUIT_NEW→NOTIFICATION_SEND
+   │   ← 재작성 0 (현행 유지)                │       →dmSender(REST)→NOTIFICATION_SENT
+   └─ EventBus #1 (프로세스 로컬)           └─ EventBus #2 (프로세스 로컬)
+              │                                        ▲
+              └──────► ③ Firestore 트리거 ◄───────────┘
+                       (크로스-프로세스만, 2.1/2.2에서 배선)
+```
+
+- **인터랙션은 gateway 유지** → HTTP Interactions 전환에 따르는 Ed25519 서명검증·3초 응답·cold start UX 문제를 회피(재작성 0).
+- **크롤·알림은 serverless** → 크롤(Playwright, 무거움)을 온디맨드로 격리, scale-to-zero로 상시 크롤 비용 회피.
+- **크로스-프로세스 이벤트는 Firestore 트리거**(DB-as-bus) — 기록 저장 방침과 정합(2.1 에러 로그가 저장=발행). 인트라-프로세스(크롤→DM)는 EventBus 그대로.
+
+### 영향 받는 파일
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `app/index.ts` | 수정 | 진입점 분리 (gateway / 함수 부트스트랩) |
+| `crawlers/schedulers/base/BaseScheduler.ts` | 수정 | `setTimeout` 루프 격리, onSchedule 전환 |
+| `crawlers/schedulers/RecruitScheduler.ts` | 수정 | `getRecruitList` → `crawlAndDiff` 경로 전환 |
+| `services/recruitService.ts` (또는 신규 모듈) | 수정/신규 | `crawlAndDiff(mode)` 신설, 3-tier 경로 보존 |
+| `providers/discord/utils/dmSender.ts` | 수정 | gateway → REST 전용 (계약 불변) |
+| `providers/discord/client.ts` | 수정 | REST 클라이언트 분리/추가 |
+| onSchedule 진입점 (신규) | 신규 | Cloud Scheduler 트리거 함수 |
+
+> 정확한 파일 경계·신설 위치는 design 단계에서 확정.
+
+### 의존성 분석
+
+- **선행**: Phase 1.9(startup wiring·로컬 E2E 방식) 완료 — 본 Phase의 로컬 검증이 1.9 방식 재사용.
+- **후속**: Phase 1.10(proxy + 실 CRAWL + 실배포 + 프로덕션 E2E)이 본 Phase 산출물을 전제로 배포·실발화. Phase 2.1/2.2가 durable bus(Firestore 트리거) 배선을 처음 필요로 함.
+
+---
+
+## 성공 기준
+
+- [ ] §1 런타임 결정(C안)이 design §1에 트레이드오프·비용·계약 영향과 함께 고정됨
+- [ ] 진입점 분리·onSchedule·dmSender REST·`crawlAndDiff`·틱 완결 파이프라인이 코드로 완성되고 정적 analyze 통과
+- [ ] `DmPayload`/`DmSendResult` 계약 불변 확인
+- [ ] `getRecruitList` 3-tier 경로 무회귀 확인
+- [ ] 인터랙션 수신 코드 무변경 확인
+- [ ] 로컬 DUMMY E2E에서 REST DM 수신 + `crawlAndDiff` diff 발행 확인
+- [ ] TypeScript 컴파일 성공 (`npx tsc --noEmit`)
+- [ ] 실배포·실 CRAWL·프로덕션 E2E는 범위 밖 (→ Phase 1.10)
+
+---
+
+## 리스크 및 고려사항
+
+| 리스크 | 영향도 | 대응 방안 |
+|--------|--------|----------|
+| §1 런타임 결정이 #2·#3을 강결합 | 🔴 높음 | design §1을 CTO 승인으로 잠근 뒤 do 진입 (§1이 do 게이트) |
+| EventBus 프로세스-로컬화 (C안 프로세스 분리) | 🔴 높음 | 인트라-프로세스는 EventBus 유지. 크로스-프로세스는 Firestore 트리거로 가는 방향을 design §1 계약에 명시, 실제 배선은 2.1/2.2 예약 |
+| `DmPayload`/`DmSendResult` 계약 파손 | 🟡 중간 | REST 전환은 계약 외 내부 변경으로만. analyze Contract 차원 필수 검증. 소비자(NotificationSendHandler, 2.1/2.2) 회귀 점검 |
+| `crawlAndDiff` 신설 시 `getRecruitList` 회귀 | 🟡 중간 | 두 경로가 `setRecruitList`(Redis hash diff) 공유 — 사용자 경로 보존, diff 정합성 유지 |
+| onSchedule 실발화·REST 실전송·서명 무관 실 CRAWL 미검증 | 🟡 중간 | 1.13은 코드+정적/로컬 한정. 실발화 검증은 1.10 배포로 이월(감수된 스코프), report에 명시 |
+| gateway 상시 프로세스 비용·인프라(Cloud Run) | 🟡 중간 | slim 프로세스(인터랙션 수신 전용). 실배포·인프라 프로비저닝은 1.10 |
+
+---
+
+## 위임 계획 (CTO Lead 승인 완료)
+
+| 영역 | 위임 대상 | 근거 | 예상 산출물 |
+|------|----------|------|-------------|
+| §1 런타임 결정(C안) + #0 진입점 분리 + #2 onSchedule + #4 파이프라인 + #5 crawlAndDiff | **Integration Lead** (primary, design.md 작성) | provider orchestration + 런타임이 스케줄러·dmSender 양쪽 계약 지배 | design §1 고정안 + onSchedule/진입점/crawlAndDiff 코드 |
+| #3 dmSender REST 전환 | **Discord Agent** (co-author, REST 섹션) | discord.js REST 도메인, "DM 발송" 트리거 | REST 전용 `sendNotificationDM` (계약 불변) |
+| #5 Redis hash diff 정합성 | **Backend Expert** (Integration Lead가 위임) | 데이터 계층 diff 엔진 정합 | hash 생성·비교 정합성 확보 |
+
+**design.md 작성**: Integration Lead(primary) + Discord Agent(co-author, dmSender REST 섹션).
+
+---
+
+*작성일: 2026-08-04*
+*시드: .claude/phases/phase-1-core.md*

--- a/docs/archive/phase-1-13/02-design.md
+++ b/docs/archive/phase-1-13/02-design.md
@@ -1,0 +1,408 @@
+# Phase 1.13 설계서: 프로덕션 런타임 & 스케줄러 트리거 재설계
+
+**상태**: 🔄 진행 중
+**기반 문서**: `docs/phase-1-13/01-plan.md`
+**작성자**: Integration Lead (primary) + Discord Agent (co-author, §2.5 dmSender REST)
+
+---
+
+## 1. 아키텍처 설계
+
+### 1.0 런타임 결정 — C안 하이브리드 (고정)
+
+Phase 1.13은 배포 런타임을 **두 프로세스로 분리하는 C안 하이브리드**로 고정한다.
+이 결정이 #2(onSchedule)·#4(틱 완결)·#5(crawlAndDiff)를 강결합으로 지배하므로,
+본 §1이 `do` 진입 게이트다(plan 리스크 표 R1).
+
+| 프로세스 | 역할 | 열리는 것 | 안 열리는 것 |
+|----------|------|-----------|--------------|
+| ① Gateway (상시·slim) | 인터랙션 수신(슬래시/버튼/모달/셀렉트) | discord.js Client WebSocket 로그인, `onInteraction` 리스너, ready 빗장, Firebase, Redis | 스케줄러 (미시작) |
+| ② Serverless 함수 (scale-to-zero) | onSchedule 크롤 → diff → 알림 | Firebase, Redis, Discord **REST**(로그인 없음), `onSchedule` 트리거 | gateway WebSocket, ready 대기 |
+
+**트레이드오프 / 비용 / 계약 영향** (plan 요구 §1):
+
+- **인터랙션 = gateway 유지 (재작성 0)**: HTTP Interactions 전환에 따르는 Ed25519 서명검증·3초 응답 창·cold start UX 리스크를 회피한다. `onInteraction.ts`/`discordListeners.ts` **무변경**이 계약이다.
+- **크롤·알림 = serverless**: Playwright 크롤을 온디맨드로 격리하고 scale-to-zero로 상시 크롤 비용을 없앤다. 대가로 **서버리스 CPU 동결**이 발생하므로, 한 tick이 CPU 동결 전에 크롤→diff→DM(REST)까지 **await로 완결**되어야 한다(§2.3).
+- **비용**: gateway는 상시 프로세스(Cloud Run min-instance)라 상시 비용이 있으나 인터랙션 수신 전용 slim 프로세스로 최소화한다. 실제 인프라 프로비저닝·실배포는 **Phase 1.10 이월**.
+- **순차 발송 블로킹 비용**: 틱 완결 파이프라인이 구독자별 DM을 순차 await하는 블로킹 비용은 **인지만** 하고 실측은 1.10 E2E로 이월한다(plan 비기능 요구).
+
+### 1.1 EventBus 계약 — 프로세스-로컬화 (필수 문장화)
+
+`EventBus`는 프로세스별 Singleton(`EventBus.getInstance()`)이다. C안이 런타임을 **두 개의 독립 Node 프로세스**로 쪼개므로, 각 프로세스는 **서로 다른 EventBus 인스턴스**를 갖는다 — 즉 EventBus가 자연히 **프로세스-로컬화**된다. 이 사실을 계약으로 문장화한다:
+
+- **Gateway 프로세스 = EventBus #1**: 인터랙션 유발 이벤트(예: `RECRUIT_REQUESTED`, `NOTIFICATION_SUBSCRIBE`)가 이 프로세스의 EventBus에만 존재한다.
+- **함수 프로세스 = EventBus #2**: 스케줄러 tick의 `RECRUIT_NEW → NOTIFICATION_SEND → NOTIFICATION_SENT` 체인이 이 프로세스의 EventBus에만 존재한다.
+- **인트라-프로세스(크롤 → DM) = EventBus 유지**: 함수 프로세스 안에서 크롤부터 DM 발송까지는 전부 EventBus #2 안에서 완결된다(§2.3). 크로스-프로세스 배선이 **필요 없다** — 1.13의 핵심 파이프라인은 단일 함수 프로세스 내부에서 닫힌다.
+- **크로스-프로세스 이벤트 = Firestore 트리거(DB-as-bus) 방침**: 한 프로세스의 이벤트를 다른 프로세스가 소비해야 하는 경우(예: gateway 인터랙션이 즉시 크롤을 유발, 또는 함수 결과를 gateway가 관찰)는 EventBus로 넘길 수 없다(인스턴스가 분리됨). 이때는 **Firestore 트리거(DB-as-bus)**로 간다 — "기록 저장 = 발행" 방침(2.1 에러 로그 저장)과 정합한다.
+- **스코프 경계**: 위 크로스-프로세스 배선(Firestore 트리거)의 **실제 구현은 Phase 2.1/2.2로 이월**한다. 1.13은 이 방침을 **계약으로 명시만** 하고, 실제 트리거·리스너 코드는 작성하지 않는다.
+
+### 1.2 계약 불변 (필수 명시)
+
+1.13 전 과정에서 아래 세 계약은 **불변**이며 analyze Contract 차원 필수 검증 대상이다:
+
+- **`DmPayload` / `DmSendResult` 불변**: dmSender REST 전환(§2.5)은 계약 외 내부 변경으로만 수행한다. 시그니처·필드 무변경(1.9/1.10/2.1/2.2 공유 계약).
+- **`getRecruitList` 3-tier 무회귀**: `crawlAndDiff`는 `getRecruitList`를 우회하는 **별도 경로**다. `getRecruitList` 본문은 수정하지 않는다(§2.4).
+- **인터랙션 수신 코드 무변경**: `onInteraction.ts`, `discordListeners.ts`는 손대지 않는다(§1.0).
+
+### 1.3 레이어 매핑
+
+| 프로젝트 레이어 | 변경 내용 |
+|----------------|----------|
+| App 진입점 (`functions/src/app/`) | **진입점 분리** — `index.ts`=gateway 부트스트랩(스케줄러 미시작), `scheduler.ts`(신규)=함수 부트스트랩 + `onSchedule` 트리거 (§2.1) |
+| Providers (`functions/src/providers/`) | ① provider 번들 분리(`initGatewayProviders`/`initFunctionProviders`) — 배선 소유(§2.1). ② `discord/` REST 분리·dmSender REST — **Discord Agent 소유**(§2.5) |
+| Crawlers/Schedulers (`functions/src/crawlers/schedulers/`) | `BaseScheduler` setTimeout 루프 → `runOnce()` 추출(awaitable 단일 tick), `onSchedule`가 호출. `RecruitScheduler.performWork`가 `getRecruitList` → `crawlAndDiff` 전환 (§2.2) |
+| Services (`functions/src/services/`) | `RecruitService.crawlAndDiff(mode)` 신설(스케줄러 전용). `RecruitCacheService.setRecruitList` 반환값 확장 + emit 추출. `notificationService`가 awaitable 발행로 전환 (§2.3, §2.4) |
+| Events (`functions/src/events/`) | 인터랙션 수신(`onInteraction`/`discordListeners`) **무변경**. 핸들러 등록(`registerAllEventHandlers`)은 두 프로세스가 각자 호출 (§2.1) |
+| EventBus (`functions/src/events/bus/`) | **additive**: `emitEventAndSettle`(리스너 promise 수집·await) 추가. 기존 `emitEvent` 불변 (§2.3) |
+| Common (`functions/src/common/`) | 공용 emit 헬퍼(`emitRecruitNewEvent`) 위치 후보 — 두 발행부(user path·crawlAndDiff)가 CHANGED gating 공유 (§2.4) |
+
+### 1.4 컴포넌트 다이어그램
+
+```
+① Gateway 프로세스 (상시·slim)              ② Serverless 함수 (scale-to-zero)
+┌──────────────────────────────┐          ┌───────────────────────────────────────┐
+│ app/index.ts                 │          │ app/scheduler.ts (신규)               │
+│  initGatewayProviders()      │          │  initFunctionProviders()              │
+│   ├─ Firebase                │          │   ├─ Firebase                         │
+│   ├─ Redis                   │          │   ├─ Redis                            │
+│   └─ Discord Gateway(WS+ready)│          │   └─ Discord REST (로그인·ready 없음) │
+│  registerAllEventHandlers()  │          │  registerAllEventHandlers()           │
+│  onInteraction (무변경)      │          │  onSchedule(4h) → scheduler.runOnce() │
+│                              │          │    └─ crawlAndDiff(mode)              │
+│  EventBus #1 (프로세스 로컬) │          │       ├─ 강제 크롤                    │
+└──────────────────────────────┘          │       ├─ setRecruitList (hash diff)   │
+              │                            │       └─ await emitEventAndSettle      │
+              │                            │            RECRUIT_NEW                 │
+              │                            │             → NOTIFICATION_SEND        │
+              │                            │              → dmSender(REST)          │
+              │                            │               → NOTIFICATION_SENT      │
+              │                            │  EventBus #2 (프로세스 로컬)          │
+              │                            └───────────────────────────────────────┘
+              │                                        ▲
+              └────────► ③ Firestore 트리거 ◄──────────┘
+                         (크로스-프로세스만 · 방침만 명시 · 배선 2.1/2.2 이월)
+```
+
+---
+
+## 2. 상세 설계
+
+### 2.1 진입점 분리 (gateway / 함수 부트스트랩)
+
+**파일**: `functions/src/app/index.ts`(수정 = gateway), `functions/src/app/scheduler.ts`(신규 = 함수), `functions/src/providers/index.ts`(수정 = 번들 분리)
+
+**문제**: 현재 `app/index.ts`가 단일 부트스트랩으로 provider init + `registerAllEventHandlers` + `initializeSchedulers`(setTimeout) + express를 모두 eager 실행한다(`app/index.ts:24-38`). C안은 프로세스가 둘로 갈리므로 각 프로세스가 **필요한 것만** init해야 한다.
+
+**provider 번들 분리** — 현재 `initializeProviders()`는 `Promise.all([initFirebaseApp, initRedis, initDiscordBot])`를 묶는다(`providers/index.ts:13-17`). 이를 프로세스별 번들로 쪼갠다:
+
+**타입/시그니처 정의**:
+```typescript
+// providers/index.ts
+export function initGatewayProviders(): Promise<void>;  // Firebase + Redis + initDiscordBot(gateway WS+login+ready 빗장)
+export function initFunctionProviders(): Promise<void>; // Firebase + Redis + initDiscordRest(REST만·login/ready 없음)
+```
+
+- `initGatewayProviders`: 기존 `initializeProviders`와 동일한 3종(Firebase/Redis/`initDiscordBot`). gateway는 인터랙션 핸들러가 서비스(Redis/Firestore)를 호출하므로 셋 다 필요하며, ready 빗장은 **인터랙션 UX용으로 유지**한다.
+- `initFunctionProviders`: Firebase + Redis + **REST 전용 Discord init**. gateway WebSocket을 열지 않고 `client.login()`을 호출하지 않으며 ready 빗장을 **대기하지 않는다**. REST 클라이언트 분리(`initDiscordRest`)는 **Discord Agent 소유**(§2.5) — 본 배선은 그 함수를 호출하는 지점만 정의한다.
+- 두 번들 모두 메모이즈 패턴(`initPromise`)을 유지해 중복 실행을 막는다.
+
+**client.ts 경계 (CTO 확정)**: "`discord/` 디렉토리 안"(REST 클라이언트 분리·`dmSender`·`getDiscordReady` 제거)은 **Discord Agent 소유**다. "누가 언제 호출하느냐(부트스트랩 배선)"만 Integration Lead가 소유한다 → 본 §2.1은 **gateway 프로세스는 인터랙션용 ready 빗장을 유지 / 함수 프로세스는 ready를 대기하지 않는다**는 호출 계약만 확정한다.
+
+> **`getDiscordReady` 제거 범위 (오독 방지)**: 여기서 "제거"는 **dmSender 호출부의 `await getDiscordReady()` 삭제만** 뜻한다. `discordReady` 모듈과 `markDiscordReady`는 **gateway 프로세스에 그대로 존치**한다(인터랙션 UX용 ready 빗장). 즉 dmSender만 ready를 기다리지 않을 뿐, gateway의 ready 게이트 자체는 유지된다.
+
+**gateway 부트스트랩** (`app/index.ts`):
+```typescript
+// pseudo — 스케줄러 시작 제거가 핵심
+registerGlobalErrorHandlers();
+initGatewayProviders()
+  .then(() => {
+    registerAllEventHandlers();   // EventBus #1 핸들러 등록
+    // ❌ initializeSchedulers 제거 — gateway는 스케줄러를 시작하지 않는다.
+  })
+  .catch((e) => globalLogger.error("gateway bootstrap failed:", e));
+const expressApp = initExpress();
+const appServer = firebaseDeploy(expressApp);
+```
+
+**함수 부트스트랩** (`app/scheduler.ts`, 신규):
+```typescript
+// pseudo
+registerGlobalErrorHandlers();
+const ready = initFunctionProviders().then(() => registerAllEventHandlers()); // EventBus #2 핸들러 등록
+
+// 프로덕션 트리거 (코드만 — 실발화·실배포는 1.10)
+export const recruitSchedule = onSchedule("every 4 hours", async () => {
+  await ready;
+  await SchedulerManager.getInstance().runRecruitOnce(CRAWL_MODE.CRAWL); // §2.2
+});
+
+// 로컬 DUMMY E2E (1.9 auto-E2E 대체) — env 게이팅
+if (process.env.RUN_SCHEDULER_ONCE === "true") {
+  ready.then(() => SchedulerManager.getInstance().runRecruitOnce(CRAWL_MODE.DUMMY));
+}
+```
+
+- 1.9는 gateway 부트스트랩에서 DUMMY 스케줄러를 eager 시작해 "첫 크롤 = auto E2E"였다. 이제 스케줄러가 gateway에서 사라지므로, **함수 부트스트랩의 env 게이팅 1회 invoke**가 그 역할을 대체한다.
+- `onSchedule`는 firebase-functions v2 `onSchedule`(Cloud Scheduler)로 정의한다. **실제 발화·실 CRAWL·실배포는 Phase 1.10 이월**(코드/정적만).
+
+**에러 처리**: 두 부트스트랩 모두 `registerGlobalErrorHandlers()`를 **가장 먼저** 등록(init 중 미처리 rejection 포획). init 실패는 흡수·로깅하되 프로세스 목적별로 분기(gateway는 HTTP를 막지 않음, 함수는 tick 실패를 `RECRUIT_CRAWL_FAILED`로 발행).
+
+### 2.2 onSchedule 전환 (setTimeout 루프 → 단일 tick)
+
+**파일**: `functions/src/crawlers/schedulers/base/BaseScheduler.ts`(수정), `RecruitScheduler.ts`(수정), `SchedulerManager.ts`(수정)
+
+**문제**: `BaseScheduler`가 in-process `setTimeout` 자기-재스케줄 루프(`BaseScheduler.ts:119-121`)로 cadence를 소유한다. 서버리스에서는 응답 후 CPU가 동결되어 4시간 타이머가 발화하지 않는다. cadence를 **Cloud Scheduler(onSchedule)**로 넘기고, `BaseScheduler`는 **단일 tick**만 책임진다.
+
+**핵심 로직 (factoring)**:
+```typescript
+// BaseScheduler — 단일 tick을 awaitable로 추출
+abstract class BaseScheduler {
+  // STARTED emit → performWork() → COMPLETED/FAILED emit. 다음 tick 재스케줄 없음.
+  async runOnce(): Promise<WorkResult>;
+
+  // 로컬 장기 실행 전용: runOnce()를 setTimeout으로 감싸 루프. 프로덕션 미사용.
+  startWork(): void;  // 내부적으로 runOnce() 호출 후 scheduleNextExecution()
+}
+```
+
+- 기존 `scheduleNextWork()`의 STARTED/COMPLETED/FAILED 이벤트 발행 + `performWork()` 호출부를 **`runOnce()`로 이동**하고, **결과를 반환**한다(awaitable). `runOnce()`는 `scheduleNextExecution()`을 **호출하지 않는다** — 이것이 "setTimeout 루프 격리"다.
+- `startWork()`(로컬 장기 실행)는 `runOnce()` → `scheduleNextExecution()`(setTimeout으로 다시 `runOnce`) 형태로 남겨 로컬 개발 cadence를 보존한다. 프로덕션 함수 프로세스는 `startWork()`를 쓰지 않고 `onSchedule`가 매 tick `runOnce()`를 await한다.
+- `SchedulerManager`에 `runRecruitOnce(mode)` 추가 — RecruitScheduler 인스턴스를 얻어 `runOnce()`를 await 반환(onSchedule/로컬 게이팅이 호출).
+
+**RecruitScheduler.performWork 전환**:
+```typescript
+// AS-IS: getRecruitList가 3-tier 캐시에 걸려 Step4 크롤에 도달하지 못함
+// const { data } = await this.recruitService.getRecruitList(this.mode);
+// TO-BE: 스케줄러 전용 crawlAndDiff (3-tier 우회·강제 크롤)
+const diff = await this.recruitService.crawlAndDiff(this.mode);  // §2.4
+```
+
+**에러 처리**: `runOnce()`는 `performWork` 실패 시 `RECRUIT_CRAWL_FAILED` 이벤트를 발행하고 결과를 반환한다(현행 발행 계약 유지). `onSchedule` 래퍼는 실패를 흡수·로깅해 Cloud Scheduler 재시도 정책에 위임한다(실제 재시도 검증은 1.10).
+
+### 2.3 틱 완결 파이프라인 (awaitable emit)
+
+**파일**: `functions/src/events/bus/EventBus.ts`(additive), `services/notificationService.ts`(수정), 공용 emit 헬퍼
+
+**문제 (핵심)**: 현재 파이프라인은 **전 구간 fire-and-forget**이다. `setRecruitList`가 `eventBus.emitEvent(RECRUIT_NEW)`를 **동기 emit**하고(핸들러 promise를 버림), `notifyNewRecruits`가 구독자별 `NOTIFICATION_SEND`를 다시 fire-and-forget emit하며, `NotificationSendHandler`가 `sendNotificationDM`을 await하지만 그 promise도 emitter에서 분리(detached)된다. Node `EventEmitter.emit`은 async 리스너를 **떼어내 실행**하고 즉시 반환하므로, 서버리스 tick이 `crawlAndDiff` 반환 직후 종료되면 **in-flight DM 발송이 잘린다**. 장기 실행 프로세스에서는 이벤트 루프가 나중에 drain하므로 문제없지만 scale-to-zero와 비호환이다.
+
+**설계 — awaitable emit (additive)**:
+```typescript
+// EventBus.ts — 기존 emitEvent 불변, 신규 메서드 추가
+emitEventAndSettle<T>(event: EventType, payload: T): Promise<void>;
+// 내부: this.listeners(event)를 순회해 각 리스너를 payload로 호출,
+// 반환된 값(promise 가능)을 모아 await Promise.allSettled(...)
+```
+
+- **두 hop 모두** awaitable로 전파해야 tick이 DM 완결까지 await한다:
+  - Hop1 `RECRUIT_NEW`: crawlAndDiff가 `await emitEventAndSettle(RECRUIT_NEW, diff)` → `NotificationEventHandler`(async) promise를 await.
+  - Hop2 `NOTIFICATION_SEND`: `notifyNewRecruits`가 구독자별 `emitEvent`(fire-and-forget) → **`emitEventAndSettle`로 전환**하고 await → `NotificationSendHandler`(async) → `sendNotificationDM`(REST) promise가 상위로 전파.
+- **핸들러 등록·로직 무변경**: `NotificationEventHandler`/`NotificationSendHandler`는 이미 async 함수라 promise를 반환한다. `emitEventAndSettle`가 그 반환 promise를 수집하기만 하면 되므로 핸들러 코드는 손대지 않는다.
+- **`emitEvent` 불변**: 기존 fire-and-forget 소비자(인터랙션 유발 이벤트 등)는 그대로 둔다. `emitEventAndSettle`는 **틱 완결이 필요한 경로에서만** 사용한다.
+- **순차 발송 블로킹**: `notifyNewRecruits`가 구독자별 DM을 순차 await하면 tick 시간이 구독자 수에 선형 비례한다. 이 블로킹 비용은 **인지만** 하고 실측·최적화는 1.10 E2E로 이월(plan 비기능 요구).
+
+**에러 처리**: `Promise.allSettled`로 한 구독자 실패가 다른 구독자를 막지 않게 한다(`dmSender`는 이미 `DmSendResult`로 흡수 반환 → reject 없음). 핸들러 내부 try-catch(재throw 금지) 패턴 유지.
+
+### 2.4 스케줄러 크롤 경로 재설계 — `crawlAndDiff(mode)`
+
+**파일**: `functions/src/services/recruitService.ts`(메서드 신설), `services/recruitCacheService.ts`(반환값 확장 + emit 추출), 공용 emit 헬퍼
+
+**신설 위치 결정 — `RecruitService`의 메서드 (신규 모듈 아님)**:
+
+| 후보 | 판단 |
+|------|------|
+| **RecruitService 메서드** ✅ | `crawlAndDiff`가 필요로 하는 협력자(`CrawlService`·`RecruitCacheService`·`RecruitStore`)가 `RecruitService` 생성자에 **이미 배선**되어 있다(`recruitService.ts:27-32`). recruit 도메인 응집을 유지하고, `getRecruitList`와 같은 `setRecruitList` diff 엔진을 공유한다. |
+| 신규 모듈 | `CrawlService`/`RecruitCacheService`/`RecruitStore`와 `RedisManager` store 접근을 **재배선(중복)**해야 한다. 두 경로가 정당하게 같은 도메인 협력자·diff 엔진을 공유하므로 응집도상 불리. |
+
+→ **`RecruitService.crawlAndDiff(mode)` 메서드로 신설**한다. `getRecruitList` **무회귀**는 구조적으로 보장된다: (a) `getRecruitList` 본문 미수정, (b) `crawlAndDiff`는 `getRecruitList`의 캐시-read Step을 **읽지도 변형하지도** 않고 강제 크롤 → 공유 diff 엔진(멱등)으로 write.
+
+**핵심 로직**:
+```typescript
+// RecruitService — 스케줄러 전용. 3-tier(Step1 Redis/Step2 Firestore) 우회.
+async crawlAndDiff(mode: CRAWL_MODE): Promise<JobDiffResult> {
+  const list = await this.crawler.sriagent(mode);      // 강제 크롤 (캐시 read 없음)
+  const { status, diff } = await this.cacheService.setRecruitList(list); // §아래 factoring
+  if (status === CacheUpdateStatus.CHANGED) {
+    await emitRecruitNewEvent(diff, "RecruitService.crawlAndDiff", { awaitSettle: true }); // §2.3
+  }
+  return diff;
+}
+```
+
+- **3-tier 우회**: `getRecruitList`의 Step1(Redis)·Step2(Firestore) read를 건너뛰고 `crawler.sriagent(mode)`로 **강제 크롤**한다. 이로써 "TTL 없는 Firestore canonical doc이 항상 히트해 Step4 크롤에 도달 못 함"(plan 배경)을 해소한다.
+- **크롤 스코프 고정**: `crawlAndDiff`는 **city 미지정(전체 지역)** 결과로만 `setRecruitList`를 호출한다(Backend Expert 방어책 d). 부분 스코프 크롤 결과를 diff 엔진에 넣지 않는다 — 그렇지 않으면 다른 지역 공고가 `deletedIds`로 오판된다.
+- `crawlService.ts:28` DUMMY 버그(#6)로 DUMMY 모드 강제 크롤이 완전치 않을 수 있으나 **Phase 1.10 이월**(범위 밖).
+
+**diff 엔진 재사용 정합성 (Backend Expert 위임 결과 — 인라인 편입)**:
+
+Redis hash diff 엔진(`setRecruitList`의 `createHashes`→`hashStore.getAll()`→`diffJobs`)을 crawlAndDiff가 재사용하되, awaitable 발행을 위해 아래 factoring을 적용한다:
+
+1. **`setRecruitList` 반환값 확장 + emit 추출**: diff 계산(`diffJobs`)과 영속화(`saveAll`/`syncChanges`)는 **한 메서드 안에 원자적 순서로 유지**한다(read→write 사이 TOCTOU 창을 넓히지 않기 위해 분리하지 않는다). 대신 **내부 `eventBus.emitEvent(RECRUIT_NEW)`만 제거**하고 시그니처를 `Promise<{ status: CacheUpdateStatus; diff: JobDiffResult }>`로 확장한다. `CacheUpdateStatus` enum은 메서드 로컬 선언 → 클래스/`common/types` 레벨로 승격한다.
+2. **공용 emit 헬퍼로 CHANGED gating 공유**: emit 책임을 `emitRecruitNewEvent(diff, source, opts)` 헬퍼로 추출해 **두 발행부**(사용자 경로 `RecruitService`의 백업 write, 신규 `crawlAndDiff`)가 동일한 `status === CHANGED` gating + try-catch 방어(발행 실패가 캐시 성공을 막지 않음)를 공유한다 — emit 시맨틱 drift 방지.
+3. **사용자 3-tier 무회귀 보장**: `getRecruitList`의 두 백업 호출(Step2 Firestore, `collectAndSaveRecruits`)은 `setRecruitList(...).catch()`로 **반환값을 무시**하므로 `void → Promise<{status,diff}>` 확장에도 fire-and-forget 동작이 문법·동작 100% 유지된다. **단** 내부 emit 제거로 "사용자 크롤 시 CHANGED면 알림 발행"이 사라지므로, 이 두 호출부에 `.then(({status,diff}) => status===CHANGED && emitRecruitNewEvent(diff, "RecruitService", { awaitSettle:false }))`를 **추가**해 기존 알림 계약을 재현한다(= 무회귀는 "emit 위치 이관 + 조건·방어 동일 재현"이 핵심).
+4. **hash 상태 공유 경합 방어**: 두 경로(사용자 백업 write·스케줄러 강제 크롤 write)가 같은 Redis `hashStore`/`cacheStore`를 공유 → 동시 진입 시 같은 `currentHashes`를 읽어 **중복 emit**(같은 addedJobs 2회 알림)·부분 갱신 경합 가능. 방어책: `crawlAndDiff` 시작 시 **Redis 분산 락(`SET NX PX`)**으로 diff 계산~저장 구간의 원자성을 확보한다(락은 두 경로가 같은 키 공간을 쓰는 이상 유일한 실용적 수단). 락 도입은 **본 Phase 검토·설계 포함, 정합성 필수**. (이벤트 소비자 레벨 dedup은 알림 계층 사안 → 범위 밖.)
+5. **NO_DATA 판정의 스케줄러 타당성**: `hashStore.getAll()`이 null(최초/TTL 만료)이면 NO_DATA → 전량 저장만 하고 **RECRUIT_NEW 미발행**. 이는 "기준선 부재 시 전체를 새 공고로 발행하면 수백 건 DM 스팸"을 막는 **의도된 동작**이다. 단 스케줄러가 변경 감지의 신뢰 경로가 되므로, NO_DATA를 "정상 diff 스킵"과 구분하도록 **로그 레벨 격상(info→warn)**을 권장한다. UNCHANGED(`extendExpiration`)·CHANGED는 호출 주체와 무관하게 diff가 순수 비교라 그대로 타당.
+
+**에러 처리**: `emitRecruitNewEvent` 헬퍼는 발행 실패를 try-catch로 흡수(캐시 갱신은 이미 성공). 크롤 실패는 `crawlAndDiff`가 throw → `runOnce()`가 `RECRUIT_CRAWL_FAILED` 발행(§2.2).
+
+### 2.5 dmSender REST 전환
+
+**파일**: `functions/src/providers/discord/client.ts`(REST 클라이언트 추가), `functions/src/providers/discord/utils/dmSender.ts`(gateway 의존 제거·2-step REST 전환)
+
+**문제**: 현재 `sendNotificationDM`은 **gateway 의존 2점**을 갖는다 — (a) 발송 직전 `await getDiscordReady()`(gateway ClientReady 빗장, `dmSender.ts:117`), (b) `client.users.fetch(userId)` + `user.send()`(gateway 캐시/WS 경로, `dmSender.ts:122-123`). C안 함수 프로세스는 `client.login()`을 호출하지 않고 gateway WS를 열지 않으므로(§1.0, §2.1), ready 빗장은 **영영 열리지 않고**(함수 프로세스엔 `markDiscordReady`를 호출할 ClientReady 이벤트가 없음) `client.users.fetch`도 로그인 토큰이 없어 실패한다. → DM 발송 경로를 **REST 전용**으로 전환해 gateway 로그인·ready와 완전 분리한다.
+
+#### (1) client.ts — REST 클라이언트 분리 (Discord Agent 소유)
+
+gateway `Client`(인터랙션 수신 전용)와 별개로, **독립 `REST` 인스턴스**를 노출한다. `register-commands.ts`가 이미 쓰는 `new REST({ version: "10" }).setToken(...)` 패턴을 재사용해 일관성을 지킨다. 함수 프로세스가 gateway 로그인 없이 REST만 사용할 수 있도록 토큰 주입을 `client.login()`과 분리한다.
+
+**타입/시그니처 정의**:
+```typescript
+// client.ts — 기존 gateway Client 유지 + REST 추가
+import { Client, GatewayIntentBits, REST } from "discord.js";
+
+export const client = new Client({ intents: [ /* 기존 유지 */ ] }); // gateway = 인터랙션 수신
+
+/** DM 발송 전용 REST 클라이언트 — gateway WS/login과 독립. 함수 프로세스가 사용. */
+export const rest = new REST({ version: "10" });
+
+/** REST 토큰 주입. 부트스트랩(§2.1)이 프로세스별로 호출. gateway 로그인과 무관. */
+export function initDiscordRest(): void {
+  rest.setToken(process.env.DISCORD_BOT_TOKEN!);
+}
+```
+
+- `rest`는 `client.login()`을 필요로 하지 않는다 — `setToken`만으로 REST 호출이 성립한다(gateway WS·ready 빗장 무관).
+- **호출 주체는 §2.1 소유**: `initDiscordRest()`를 **누가·언제** 부르는지(= `initFunctionProviders`가 gateway login 없이 REST init만 수행)는 부트스트랩 배선으로 §2.1이 확정한다. 본 절은 함수 시그니처와 "REST가 login과 독립"이라는 계약만 정의한다.
+- gateway 프로세스는 이 `rest`를 쓰지 않는다(DM 발송은 함수 프로세스 전담). gateway는 인터랙션용으로 `client`의 ready 빗장만 유지(§2.1).
+
+#### (2) dmSender — 2-step REST 흐름으로 전환
+
+REST로 DM을 보내려면 gateway 캐시가 없으므로 **DM 채널을 먼저 열어야** 한다. discord.js `Routes` 헬퍼로 2단계를 명시한다:
+
+**핵심 로직**:
+```typescript
+// dmSender.ts — getDiscordReady / client.users.fetch 제거
+import { rest } from "@/providers/discord/client";
+import { Routes } from "discord.js";
+
+// (기존) await getDiscordReady();  ← 삭제. REST는 ready 빗장 불필요.
+// while 재시도 루프 내부:
+try {
+  // 1) DM 채널 개설 — POST /users/@me/channels { recipient_id }
+  const dmChannel = (await rest.post(Routes.userChannels(), {
+    body: { recipient_id: userId },
+  })) as { id: string };
+
+  // 2) 메시지 전송 — POST /channels/{id}/messages
+  await rest.post(Routes.channelMessages(dmChannel.id), {
+    body: { embeds: toApiEmbeds(payload.embeds), content: payload.content },
+  });
+
+  return { ok: true, durationMs: Date.now() - startedAt, attempts };
+} catch (error) { /* (3) 아래 에러 매핑 — 기존 분기 그대로 */ }
+```
+
+- **embeds 정규화(내부 변환)**: gateway `user.send()`는 `EmbedBuilder` 객체를 자동 직렬화했으나, raw REST body는 **`APIEmbed` JSON**만 받는다. `DmPayload.embeds`(= `MessageCreateOptions["embeds"]`, 빌더 가능)를 `toApiEmbeds()`로 `.toJSON()` 정규화한다(빌더면 `toJSON()`, 이미 API 객체면 통과). **계약 밖 내부 변환** — `DmPayload` 필드·의미는 불변이고 호출 측 빌더 산출물 전달 방식도 그대로다.
+- `Routes.userChannels()` = `POST /users/@me/channels`, `Routes.channelMessages(id)` = `POST /channels/{id}/messages` (discord-api-types 헬퍼, `register-commands.ts`의 `Routes` 사용과 동일 계열).
+
+#### (3) 계약 불변 (§1.2 준수 · 소비자 영향 0)
+
+- **시그니처 동결**: `sendNotificationDM(userId: string, payload: DmPayload): Promise<DmSendResult>` — 매개변수·반환 타입 불변.
+- **`DmPayload` / `DmSendResult` 구조·필드 불변**: `embeds`/`content` 입력, `ok`/`skipped`/`reason`/`errorCode`/`durationMs`/`attempts` 출력 전부 그대로. REST 전환은 **함수 본문 내부 변경으로만** 수행한다(§1.2 계약).
+- **소비자 영향 0 명시**: `NotificationSendHandler`(§2.3 Hop2 소비자) 및 Phase 1.9/1.10/2.1/2.2 공유 계약은 시그니처·결과 구조가 동일하므로 **무변경**. §2.3의 `emitEventAndSettle` await 체인은 `sendNotificationDM`이 반환하는 promise만 수집하면 되고 반환 형태가 불변이라 그대로 연결된다.
+- `MAX_ATTEMPTS=3`(최초 1 + 재시도 2), `BASE_BACKOFF_MS`, `FALLBACK_RATE_LIMIT_MS` 상수와 순차 재시도 루프 구조도 유지.
+
+#### (4) 에러 처리 보존 — gateway 예외 → REST 응답 매핑
+
+REST 전환으로 예외 **형태**가 gateway 예외 → REST `DiscordAPIError`/`HTTPError`로 바뀌지만, 기존 에러코드 추출·분기 의미를 **동일 코드값**으로 보존한다. providers 계층 규칙대로 **throw 금지·`DmSendResult`로 흡수 반환**을 유지한다.
+
+| 기존 분기 (gateway) | REST 대응 | 추출 경로 | 처리 (불변) |
+|--------------------|-----------|-----------|-------------|
+| `50007` DM 차단/공유 길드 없음 | `DiscordAPIError.code === 50007` (채널 개설 step1 또는 전송 step2에서 발생) | `getErrorCode(err)` = `.code`(number) | graceful skip `{ ok:false, skipped:true, reason:"dm_disabled" }`, 재시도 없음 |
+| `10013` Unknown User | `DiscordAPIError.code === 10013` (step1 recipient_id 무효) | `getErrorCode(err)` = `.code` | 실패 `{ ok:false, reason:"unknown_user" }`, 재시도 없음 |
+| `429` / RateLimitError | REST 내부 큐 흡수(`rejectOnRateLimit: null` 기본)로 보통 미노출. 방어적으로 `RateLimitError`(`retryAfter`/`timeToReset` ms) 또는 `DiscordAPIError.status === 429` | `getRateLimitWaitMs(err)` (ms, `*1000` 금지) | 대기 후 재시도 |
+| 그 외 미지 코드 | `HTTPError`/`DiscordAPIError`(5xx 등) | `getErrorCode` = undefined | 짧은 backoff 후 재시도, 소진 시 `{ ok:false, reason:"max_retries" }` |
+
+- **에러코드 매핑 정합성(핵심)**: `DiscordAPIError.code`는 **gateway·REST 무관하게 동일한 Discord 에러 코드**(50007/10013)를 노출한다. 따라서 기존 `getErrorCode()`(`.code`가 number일 때만 반환)·`getRateLimitWaitMs()`는 **수정 없이 REST 예외에서도 같은 코드를 추출**한다. 단 REST는 `.status`(HTTP)도 함께 가지므로, 429 방어 분기의 `e.status === 429` 경로가 REST에서 더 정확히 작동한다(기존 로직 유지로 충분).
+- **2-step의 에러 귀속**: step1(채널 개설)·step2(전송) 예외를 **동일 `try`로 감싸** 기존 단일 catch 분기 체계를 그대로 재사용한다 — 어느 step에서 던져도 `code`/`status` 기반 분류가 동일하게 적용된다.
+- **재시도 3회 + 429 `retry_after` 보존**: REST 내부 큐가 대부분의 rate limit을 흡수하지만, 방어적 `getRateLimitWaitMs` 대기값(ms)·최대 3회 루프는 유지한다(중복 대기 우려 없음 — REST 큐 대기와 애플리케이션 재시도는 계층이 다르며 기존 계약).
+
+---
+
+## 3. 데이터 설계
+
+### 3.1 Firestore 컬렉션/문서 구조
+
+본 Phase는 **신규 컬렉션·스키마 변경 없음**. `getRecruitList`/`crawlAndDiff`는 기존 recruit canonical doc과 Redis hash/cache store를 그대로 사용한다. 크로스-프로세스 Firestore 트리거(DB-as-bus)는 **방침만 명시**하며 컬렉션 설계는 Phase 2.1/2.2 이월.
+
+### 3.2 이벤트 페이로드
+
+본 Phase는 **신규 이벤트 타입 없음** — 기존 이벤트가 함수 프로세스(EventBus #2)에서 awaitable로 흐른다. 페이로드 계약 전부 **불변**.
+
+| 이벤트 타입 | 페이로드 | 발행 시점 | 변경 |
+|------------|---------|----------|------|
+| `RECRUIT_CRAWL_STARTED` | `RecruitCrawlStartedEvent` | `runOnce()` tick 시작 | 불변 |
+| `RECRUIT_CRAWL_COMPLETED` | `RecruitCrawlCompletedEvent` | `runOnce()` performWork 성공 | 불변 |
+| `RECRUIT_CRAWL_FAILED` | `RecruitCrawlFailedEvent` | `runOnce()` performWork 실패 | 불변 |
+| `RECRUIT_NEW` | `RecruitNewEvent` (`JobDiffResult`) | `crawlAndDiff` diff=CHANGED 시 (emit 위치만 `setRecruitList` 내부 → 공용 헬퍼로 이관) | 페이로드 불변 |
+| `NOTIFICATION_SEND` | `NotificationSendEvent` | `notifyNewRecruits` 구독자별 (emit → `emitEventAndSettle`로 전환, 페이로드 동일) | 페이로드 불변 |
+| `NOTIFICATION_SENT` | `NotificationSentEvent` | `NotificationSendHandler` DM 발송 후 | 불변 |
+
+> **메서드 추가(계약 아님)**: `EventBus.emitEventAndSettle`는 additive 메서드로, `EventPayloadMap`·기존 `emitEvent` 계약을 변경하지 않는다.
+
+---
+
+## 4. 구현 순서
+
+| 순서 | 작업 | 파일 | 설계 섹션 |
+|------|------|------|----------|
+| 1 | `EventBus.emitEventAndSettle` 추가 (additive) | `events/bus/EventBus.ts` | §2.3 |
+| 2 | `setRecruitList` 반환값 확장 + 내부 emit 제거, `CacheUpdateStatus` enum 승격 | `services/recruitCacheService.ts` | §2.4 |
+| 3 | 공용 `emitRecruitNewEvent(diff, source, opts)` 헬퍼 신설 (CHANGED gating + try-catch) | `common/...` | §2.4 |
+| 4 | `RecruitService`: `getRecruitList` 두 백업 호출부에 emit 헬퍼 배선(무회귀), `crawlAndDiff(mode)` 신설 + Redis 분산 락 | `services/recruitService.ts` | §2.4 |
+| 5 | `notifyNewRecruits` → `emitEventAndSettle`로 전환 (await 전파) | `services/notificationService.ts` | §2.3 |
+| 6 | `BaseScheduler` `runOnce()` 추출(setTimeout 루프 격리), `startWork` 재구성 | `crawlers/schedulers/base/BaseScheduler.ts` | §2.2 |
+| 7 | `RecruitScheduler.performWork` → `crawlAndDiff`, `SchedulerManager.runRecruitOnce` | `crawlers/schedulers/RecruitScheduler.ts`, `SchedulerManager.ts` | §2.2 |
+| 8 | provider 번들 분리 `initGatewayProviders`/`initFunctionProviders` | `providers/index.ts` | §2.1 |
+| 9 | gateway 부트스트랩: 스케줄러 시작 제거 | `app/index.ts` | §2.1 |
+| 10 | 함수 부트스트랩 신규 + `onSchedule` 트리거 + 로컬 env 게이팅 | `app/scheduler.ts` (신규) | §2.1 |
+| 11 | dmSender REST 전환 (**Discord Agent**) | `providers/discord/**` | §2.5 |
+
+> 순서 근거: EventBus(1) → 서비스 계층 diff/emit(2~5) → 스케줄러 단일 tick(6~7) → 진입점 배선(8~10) → dmSender REST(11, Discord Agent). §2.5는 §2.3 파이프라인이 정한 `DmPayload`/`DmSendResult` 계약 불변 하에 병행 가능.
+
+---
+
+## 5. 코딩 컨벤션 체크리스트
+
+- [ ] camelCase 변수/함수, PascalCase 클래스/인터페이스/타입
+- [ ] `SystemLogger`(`globalLogger`/`providerLogger`) 사용, `console.log` 금지
+- [ ] `SystemError` 패턴 준수, provider 계층 throw 금지(결과 흡수 반환)
+- [ ] EventBus 타입 안전 이벤트(`emitEvent`/`emitEventAndSettle` 제네릭)
+- [ ] 핸들러 내부 try-catch, emitter로 재throw 금지
+- [ ] JSDoc(public API: `runOnce`/`crawlAndDiff`/`emitEventAndSettle`/`initFunctionProviders`)
+- [ ] 한국어 주석(필요 시)
+- [ ] `DmPayload`/`DmSendResult` 계약 불변, `getRecruitList` 3-tier 무회귀, 인터랙션 수신 코드 무변경
+
+---
+
+## 6. 테스트 계획
+
+> **⚠️ 스코프 경계 (필수 명시)**: 본 테스트 계획은 **정적(TypeScript 컴파일) / 로컬 DUMMY 한정**이다. 아래는 **모두 Phase 1.10 이월**이며 1.13의 미검증을 갭으로 오탐하지 않는다: **onSchedule 실발화(Cloud Scheduler)·실 CRAWL(`recruitMode: CRAWL`)·REST 실전송·실배포(gateway Cloud Run + 함수)·프로덕션 E2E·`crawlService.ts:28` DUMMY 버그(#6)**. Firestore 트리거(크로스-프로세스 DB-as-bus) **실제 배선도 2.1/2.2 이월**(1.13은 방침만).
+
+| 검증 항목 | 방법 | 기대 결과 |
+|----------|------|----------|
+| 전체 컴파일 | `npx tsc --noEmit` | 에러 없음 |
+| 진입점 분리 | 정적 리뷰 | gateway 부트스트랩에 `initializeSchedulers` 없음, 함수 부트스트랩에 gateway WS/ready 대기 없음 |
+| `emitEventAndSettle` additive | 정적 리뷰 | 기존 `emitEvent` 시그니처·`EventPayloadMap` 불변 |
+| `runOnce()` 루프 격리 | 정적 리뷰 | `runOnce()` 내부에 `scheduleNextExecution()` 호출 없음(단일 tick) |
+| 틱 완결 await 전파 | 정적 리뷰 | `crawlAndDiff` → `emitEventAndSettle(RECRUIT_NEW)` → `notifyNewRecruits`가 `NOTIFICATION_SEND`를 await → dmSender까지 promise 체인 연결 |
+| `crawlAndDiff` 3-tier 우회 | 정적 리뷰 | Step1 Redis/Step2 Firestore read 미호출, 강제 크롤 진입, city 미지정 전체 스코프 |
+| `getRecruitList` 무회귀 | 정적 리뷰 | 본문 미수정, 두 백업 호출부에 emit 헬퍼 배선(CHANGED 알림 계약 재현) |
+| diff 정합성 (락) | 정적 리뷰 | `crawlAndDiff`에 Redis 분산 락, `setRecruitList` diff/persist 원자 순서 유지 |
+| `DmPayload`/`DmSendResult` 계약 | 정적 리뷰(Contract) | 시그니처·필드 불변 |
+| 인터랙션 수신 무변경 | 정적 리뷰 | `onInteraction.ts`/`discordListeners.ts` diff 없음 |
+| 로컬 DUMMY E2E | `RUN_SCHEDULER_ONCE=true` 로컬 실행 | `crawlAndDiff` diff 발행 + REST DM 수신(로컬 DUMMY 범위) |
+
+---
+
+*작성일: 2026-08-04*
+*참고: docs/phase-1-13/01-plan.md*

--- a/docs/archive/phase-1-13/03-analysis.md
+++ b/docs/archive/phase-1-13/03-analysis.md
@@ -1,0 +1,137 @@
+# Phase 1.13 갭 분석: 프로덕션 런타임 & 스케줄러 트리거 재설계
+
+**상태**: 🔍 검토 중
+**분석일**: 2026-08-05
+**설계서**: `docs/phase-1-13/02-design.md`
+
+> **스코프**: 코드+정적/로컬 DUMMY 한정. onSchedule 실발화·실 CRAWL·REST 실전송·실배포·프로덕션 E2E·`crawlService.ts:28` DUMMY 버그(#6)는 **Phase 1.10 이월**, Firestore 크로스-프로세스 트리거 실배선은 **2.1/2.2 이월** — 미검증을 갭으로 계산하지 않음(design §6 경계).
+
+---
+
+## 1. 갭 분석 (Gap Detector)
+
+### 1.1 Structural (가중치 0.2)
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| S1 | §2.1 gateway 부트스트랩(스케줄러 제거) | `initGatewayProviders().then(registerAllEventHandlers)`, `initializeSchedulers` 부재 | ✅ | `app/index.ts:20-29` |
+| S2 | §2.1 `app/scheduler.ts` 신규 + `onSchedule` | `recruitSchedule = onSchedule("every 4 hours", …)` + env 게이팅 | ✅ | `app/scheduler.ts:19,25` |
+| S3 | §2.1 `initGatewayProviders()` | Firebase+Redis+`initDiscordBot`, 메모이즈 | ✅ | `providers/index.ts:15-31` |
+| S4 | §2.1 `initFunctionProviders()` | Firebase+Redis+`initDiscordRest`, 메모이즈 | ✅ | `providers/index.ts:37-53` |
+| S5 | §2.5 `rest` + `initDiscordRest()` | `new REST({version:"10"})` + `setToken` 분리, index export | ✅ | `discord/client.ts:12-17`, `discord/index.ts:2` |
+| S6 | §2.3 `emitEventAndSettle<T>` additive | 존재, 기존 `emitEvent` 시그니처 불변 | ✅ | `events/bus/EventBus.ts:88` |
+| S7 | §2.4 공용 `emitRecruitNewEvent(diff,source,opts)` + export | 신규 파일 + barrel export | ✅ | `bus/utils/emitRecruitNewEvent.ts:16`, `bus/index.ts:22` |
+| S8 | §2.4 `setRecruitList` 반환 `{status,diff}` + `CacheUpdateStatus` 승격 | 반환 확장, enum 모듈 상단 export | ✅ | `recruitCacheService.ts:10-14,38-40,88` |
+| S9 | §2.4-4 `acquireLock`/`releaseLock` | `SET NX PX` + Lua CAS 해제 | ✅ | `redisManager.ts:69,78` |
+| S10 | §2.4 `crawlAndDiff(mode): Promise<JobDiffResult>` | 존재 | ✅ | `recruitService.ts:98` |
+| S11 | §2.2 `BaseScheduler.runOnce(): Promise<WorkResult>` 추출 | STARTED→performWork→COMPLETED/FAILED, 재스케줄 없음 | ✅ | `BaseScheduler.ts:49` |
+| S12 | §2.2 `SchedulerManager.runRecruitOnce(mode)` | `runOnce()` 반환 | ✅ | `SchedulerManager.ts:49` |
+| S13 | §2.2 `RecruitScheduler.performWork` → `crawlAndDiff` | `getRecruitList` 미사용, `crawlAndDiff(this.mode)` | ✅ | `RecruitScheduler.ts:39` |
+
+**Structural = 13/13 완전일치 → 100%**
+
+### 1.2 Functional (가중치 0.4)
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| F1 | §2.3 틱 완결 await 체인 (crawlAndDiff→RECRUIT_NEW→notifyNewRecruits가 NOTIFICATION_SEND await→dmSender) | Hop1·Hop2 promise 전 구간 연결 | ✅ | `recruitService.ts:115`, `NotificationEventHandler.ts:18`, `notificationService.ts:37`, `NotificationSendHandler.ts:28` |
+| F2 | §2.2 `runOnce` 내 `scheduleNextExecution` 미호출(단일 tick) | 루프는 `startWork`/`scheduleNextExecution`에만 격리 | ✅ | `BaseScheduler.ts:49-118` vs `41,123-136` |
+| F3 | §2.4 `crawlAndDiff` 3-tier 우회(강제 크롤) | `crawler.sriagent(mode)` 직접, 캐시 read 없음 | ✅ | `recruitService.ts:108` |
+| F4 | §2.4 city 미지정 전체 스코프 | `sriagent(mode)` city 미전달 | ✅ | `recruitService.ts:108` |
+| F5 | §2.4-4 Redis 분산 락 원자성 | `acquireLock(60s)` 가드 + `finally releaseLock` + 미획득 스킵 | ✅ | `recruitService.ts:100-120` |
+| F6 | §2.4-3 `getRecruitList` 두 백업부 CHANGED 알림 재현 | Step2 + `collectAndSaveRecruits` 둘 다 `.then(CHANGED && emit{awaitSettle:false})` | ✅ | `recruitService.ts:62-70,135-143` |
+| F7 | §2.4-5 NO_DATA 미발행(기준선 부재) | NO_DATA 분기 emit 없음(warn 격상), `crawlAndDiff`는 CHANGED만 | ✅ | `recruitCacheService.ts:66-70`, `recruitService.ts:114` |
+| F8 | §2.5 dmSender 2-step REST + ready 빗장 제거 | `rest.post(userChannels)`→`rest.post(channelMessages)`, `getDiscordReady`/`users.fetch` 삭제 | ✅ | `dmSender.ts:134-140` |
+| F9 | §2.4-1 내부 emit 제거·diff/persist 원자 순서 유지 | 내부 `emitEvent` 부재, 단일 메서드 원자 순서 유지 | ✅ | `recruitCacheService.ts:57-88` |
+| F10 | §2.3 `emitEventAndSettle` 리스너 promise 수집·allSettled | `listeners(event).map(l=>l(payload))`→`Promise.allSettled` | ✅ | `EventBus.ts:88-93` |
+
+**Functional = 10/10 완전일치 → 100%**
+
+### 1.3 Contract (가중치 0.4)
+| # | 설계 항목 (§참조) | 구현 상태 | 일치 | 파일 경로 |
+|---|-----------------|----------|------|----------|
+| C1 | §1.2 `DmPayload`/`DmSendResult` 시그니처·필드 불변 | `sendNotificationDM(userId,payload):Promise<DmSendResult>` + 필드 전부 유지 | ✅ | `dmSender.ts:12-37,122-125` |
+| C2 | §1.2 `getRecruitList` 3-tier 본문 무회귀 | read/return 로직 미변경, 백업 write에 `.then` emit 배선만(§2.4-3 지시) | ✅ | `recruitService.ts:37-91` |
+| C3 | §1.0 `onInteraction.ts`/`discordListeners.ts` 무변경 | git diff 없음 | ✅ | — |
+| C4 | §3.2 `emitEvent`·`EventPayloadMap` 불변(additive만) | 기존 `emitEvent` 그대로, `emitEventAndSettle` 추가만 | ✅ | `EventBus.ts:70-93` |
+| C5 | §3.2 이벤트 페이로드 불변 | RECRUIT_NEW/NOTIFICATION_SEND/SENT 필드 동일, 발행 위치만 이관 | ✅ | `types.ts`, `emitRecruitNewEvent.ts:21` |
+| C6 | §2.5 provider throw 금지·결과 흡수 | 전 분기 `DmSendResult` 반환 | ✅ | `dmSender.ts:144-218` |
+| C7 | §2.5-4 에러코드 매핑 보존(50007/10013/429) | `getErrorCode`·`getRateLimitWaitMs` 무수정 재사용, 2-step 단일 try | ✅ | `dmSender.ts:60-89,145-207` |
+| C8 | §2.1 gateway ready 빗장 존치 | `discordReady`/`markDiscordReady` gateway 존치, dmSender만 대기 제거 | ✅ | `discordReady.ts`, `initDiscordBot.ts` |
+
+**Contract = 8/8 완전일치 → 100%**
+
+---
+
+## 2. 매치율 산출
+
+| 카테고리 | 일치/전체 | 점수 |
+|----------|----------|------|
+| Structural (×0.2) | 13/13 | 100% |
+| Functional (×0.4) | 10/10 | 100% |
+| Contract (×0.4) | 8/8 | 100% |
+| **종합 매치율** | | **100.0%** |
+
+```
+종합 매치율 = 100×0.2 + 100×0.4 + 100×0.4 = 100.0%
+```
+
+---
+
+## 3. 갭 목록
+
+### 3.1 미구현 항목
+**실질 갭 없음** (🔴 0 / 🟡 0 / 🟢 0). 이월 항목은 스코프 밖으로 분모 미포함.
+
+### 3.2 설계 차이
+| # | 설계 내용 | 실제 구현 | 판단 |
+|---|----------|----------|------|
+| D1 | §2.4-2 락 범위 "diff 계산~저장 구간" | 락이 crawl+diff+persist+`emitEventAndSettle`(DM 브로드캐스트 await)까지 확장. TTL 60s 고정 | 허용(원자성 보장 초과 달성) — 단 §4 이슈 #1로 트레이드오프 기록, 1.10 실측 이월 |
+| D2 | §2.4 크롤 결과 diff 반영 | 빈-크롤 결과 시 `setRecruitList` 스킵 가드 추가 | 허용(설계 초과 안전장치 — 오삭제 방지 정합) |
+
+---
+
+## 4. 코드 품질 분석 (Code Analyzer)
+
+### 4.1 이슈 목록
+| # | 심각도 | 카테고리 | 파일:라인 | 이슈 내용 | 제안 |
+|---|--------|----------|----------|----------|------|
+| 1 | 🟡 Warning | 동시성/성능 | `recruitService.ts:100-120` | 락이 `awaitSettle:true`로 DM 브로드캐스트 전 구간을 감싸는데 TTL 60s 고정 → 구독자 다수/느린 크롤 시 작업 중 락 조용히 만료. persist가 emit보다 선행해 중복알림 실피해는 낮고 onSchedule 4h 주기라 동시 진입 희소 | 락 범위를 persist까지로 축소 후 emit 전 해제, 또는 TTL 재산정. 최소 report에 1.10 실측 이월로 명시 |
+| 2 | 🟢 Info | 컨벤션 | `recruitService.ts:102` | 락 TTL `60_000` 매직넘버 | `CRAWL_LOCK_TTL_MS` 상수 추출 |
+| 3 | 🟢 Info | 견고성 | `recruitCacheService.ts`, `RecruitScheduler.ts` | `import "@/common/utils/systemLogger"` side-effect 임포트 누락(전역 등록+로드 순서로 런타임 동작하나 파일 간 일관성 결여) | 두 파일 최상단 임포트 추가 |
+| 4 | 🟢 Info | DRY | `recruitService.ts:62-70`·`135-143` | `.then(CHANGED && emit).catch(warn)` gating 래핑 2회 복제(emit 자체는 헬퍼로 dedup됨) | private `backupWriteAndEmit(list)` 추출 |
+| 5 | 🟢 Info | 데드코드 | `SchedulerManager.startRecruitScheduler`/`start·stopProxyScheduler`, `initializeSchedulers`, `setupGracefulShutdown` | gateway 진입점에서 호출 제거 후 live 호출처 없음(프로덕션은 `runRecruitOnce`로 전환). `startWork` 로컬 cadence 경로도 진입점 끊김 | 버그 아님(설계 로컬 보존 의도). report에 "로컬 실행은 `RUN_SCHEDULER_ONCE=true` 단발 대체"로 명기 or 정리 |
+| 6 | 🟢 Info | 견고성 | `EventBus.ts:91` | `listeners.map(l=>l(payload))` — 동기 리스너 동기 throw 시 allSettled 격리 우회(현 핸들러는 전부 async라 안전) | `Promise.resolve().then(()=>l(payload))` 래핑 |
+| 7 | 🟢 Info | 동시성 | `recruitService.ts:119` | `finally releaseLock`가 Redis 장애로 throw 시 성공 결과 덮어써 `RECRUIT_CRAWL_FAILED` 오발행 | `releaseLock` try-catch(warn) 감싸기 |
+| 8 | 🟢 Info | 컨벤션 | `recruitService.ts:6-11` | value/type 임포트 혼재 | type 그룹 재정렬 |
+
+### 4.2 컨벤션 준수
+| 항목 | 상태 | 비고 |
+|------|------|------|
+| SystemLogger 사용(`console.*` 금지) | ✅ | 전 파일 준수 |
+| provider throw 금지(결과 흡수) | ✅ | dmSender 전 분기 `DmSendResult` |
+| 핸들러 try-catch·재throw 금지 | ✅ | Notification 핸들러 대칭 |
+| JSDoc(public API) | ✅ | runOnce/crawlAndDiff/emitEventAndSettle/initFunctionProviders/acquireLock/releaseLock |
+| EventBus 타입 안전 제네릭 | ✅ | `emitEvent<T>`/`emitEventAndSettle<T>` |
+| 네이밍 규칙 | ⚠️ | `60_000` 매직넘버(#2)만 예외 |
+| side-effect 임포트 일관성 | ⚠️ | 2개 파일 누락(#3) |
+| import 정리 | ⚠️ | #8 |
+| 보안(토큰·락·REST body) | ✅ | 하드코딩·로그유출 없음, `crypto.randomUUID`+Lua CAS, 주입 위험 없음 |
+
+### 4.3 요약
+- 🔴 Critical: 0건
+- 🟡 Warning: 1건 (#1 락 범위/TTL — 설계가 이미 인지·이월한 블로킹 트레이드오프)
+- 🟢 Info: 7건 (폴리시·저위험, 정리 커밋/iterate 일괄 처리 가능)
+- `npx tsc --noEmit`: **exit 0 (에러 0)** — 독립 재확인 포함 2회 통과
+
+---
+
+## 5. 다음 단계 분기
+
+✅ **매치율 100% (≥90%) AND 🔴 Critical 0** → `/pdca report 1.13` 진행 가능
+- CTO Lead 게이트: 매치율 ≥90% + Critical 0 → **호출 생략**(비용 절감 규칙)
+- 🟡 #1 및 🟢 7건은 **매치율 미차감** — report의 "알려진 제약/후속 정리" 항목으로 기록. #1은 1.10 실측과 함께 재검토.
+- (선택) 로컬 DUMMY E2E 런타임 검증(`RUN_SCHEDULER_ONCE=true`)은 사용자 실행 사항 — 원하면 report 전 수행 가능(강제 아님).
+
+---
+
+*분석일: 2026-08-05*
+*참고: docs/phase-1-13/02-design.md*

--- a/docs/archive/phase-1-13/04-report.md
+++ b/docs/archive/phase-1-13/04-report.md
@@ -1,0 +1,246 @@
+# Phase 1.13 완료 보고서: 프로덕션 런타임 & 스케줄러 트리거 재설계
+
+**상태**: 🔍 검토 중
+**작성일**: 2026-08-07
+**PDCA 사이클**: plan → design → do → analyze → report
+
+---
+
+## 1. 요약
+
+### 1.1 개요
+| 항목 | 내용 |
+|------|------|
+| 기능명 | 프로덕션 런타임 & 스케줄러 트리거 재설계 (C안 하이브리드) |
+| Phase | 1.13 |
+| 시작일 | 2026-08-04 |
+| 완료일 | 2026-08-07 |
+| 최종 매치율 | 100.0% |
+| 반복 횟수 | 1회 |
+
+### 1.2 목표 달성
+
+| 목표 | 달성 | 비고 |
+|------|------|------|
+| §1 런타임 결정(C안 하이브리드 확정) | ✅ | Gateway 상시(WS/인터랙션) vs Function serverless(onSchedule 크롤·알림) |
+| 진입점 분리(gateway/함수 부트스트랩) | ✅ | `initGatewayProviders`/`initFunctionProviders` + `app/scheduler.ts` 신규 |
+| setTimeout → onSchedule 전환 | ✅ | `BaseScheduler.runOnce()` 단일 tick 추출 + `onSchedule("every 4 hours")` |
+| dmSender gateway → REST 전용 | ✅ | 2-step REST(채널 개설→메시지) + `getDiscordReady` 제거·계약 불변 |
+| 틱 완결 파이프라인 | ✅ | `emitEventAndSettle` additive + Hop1·Hop2 await 전파 |
+| 스케줄러 크롤 경로 재설계(`crawlAndDiff`) | ✅ | 3-tier 우회·강제 크롤 + Redis 분산 락·diff 정합성 |
+| 정적 검증 통과 | ✅ | `npx tsc --noEmit` exit 0 |
+| 로컬 DUMMY E2E 통과 | ✅ | `RUN_SCHEDULER_ONCE=true` tick 완주 + 실 DM 0(보안) + 3 diff 케이스 검증 |
+
+---
+
+## 2. 구현 요약
+
+### 2.1 주요 변경사항
+
+1. **런타임 분리 (C안 하이브리드)**
+   - Gateway 프로세스: Discord.js Client WebSocket 로그인·ready 유지, `onInteraction` 리스너 (무변경)
+   - Function 프로세스: Firebase onSchedule 트리거, REST 전용 DM 발송, 스케줄러 로직 신규
+
+2. **부트스트랩 재구성**
+   - `app/index.ts`: `initGatewayProviders` + `registerAllEventHandlers` (스케줄러 제거)
+   - `app/scheduler.ts` (신규): `initFunctionProviders` + `onSchedule` 트리거 + 로컬 env 게이팅(`RUN_SCHEDULER_ONCE`)
+
+3. **스케줄러 로직 분리**
+   - `BaseScheduler.runOnce()` 추출: 단일 tick을 awaitable로 분리, setTimeout 루프 격리
+   - `RecruitScheduler.performWork`: `getRecruitList` → `crawlAndDiff(mode)` 전환
+   - `SchedulerManager.runRecruitOnce(mode)`: `runOnce()` 래퍼
+
+4. **틱 완결 파이프라인**
+   - `EventBus.emitEventAndSettle<T>` 신규: 기존 `emitEvent`(fire-and-forget) 불변 + additive 메서드
+   - 프로세스 내 Hop1·Hop2 promise 체인: `crawlAndDiff` → `RECRUIT_CHANGED` → `notifyNewRecruits` → `NOTIFICATION_SEND` → dmSender
+   - Firestore 트리거(크로스-프로세스): 방침 명시, 실배선 2.1/2.2 이월
+
+5. **크롤 경로 재설계 (`crawlAndDiff`)**
+   - Redis/Firestore 읽기 우회 → 강제 크롤 + 결과 diff(hash 기준) 정합
+   - Redis 분산 락(`SET NX PX` + Lua CAS): diff 계산~DM 발송까지 원자 보장 (TTL 60s)
+   - 공용 헬퍼 `emitRecruitChangedEvent(diff, source, {awaitSettle})`: CHANGED gating·try-catch 공유
+   - `getRecruitList` 3-tier 무회귀 보장: 본문 미수정 + 두 백업 호출부에 emit 헬퍼 배선
+
+6. **Discord DM 발송 전환 (REST)**
+   - `providers/discord/client.ts`: `rest` 인스턴스(gateway와 독립) + `initDiscordRest()` 함수 신설
+   - `dmSender.ts`: 2-step REST(`userChannels` → `channelMessages`) + `getDiscordReady` 제거
+   - `DmPayload`/`DmSendResult` 계약 불변: 시그니처·필드 100% 유지
+   - 에러코드 매핑 보존: 50007(DM 차단) / 10013(Unknown User) / 429(Rate Limit) 기존 분기
+
+7. **인터랙션 수신 코드 무변경**
+   - `onInteraction.ts`, `discordListeners.ts`: git diff 없음
+
+8. **이벤트 리네임 (report 검토 단계 반영)**
+   - `RECRUIT_NEW` → `RECRUIT_CHANGED` (문자열 값 `recruit:new` → `recruit:changed`): 이벤트가 add/update/delete 변경 전반을 통지하므로 "변경 감지" 의미로 정정
+   - 연동 식별자 동반 리네임: 타입 `RecruitNewEvent` → `RecruitChangedEvent`, 헬퍼/파일 `emitRecruitNewEvent` → `emitRecruitChangedEvent`
+   - 코드·living 가이드(`claude.md`) 반영 완료, EventBus 테스트 `recruit:changed`로 통과. 소비자 메서드 `notifyNewRecruits`는 의미상 유지
+   - ⚠️ 설계 문서(01-plan·02-design·03-analysis)는 설계 시점 기록으로 옛 이름(`RECRUIT_NEW`) 보존 → 이름 드리프트는 본 항목으로 설명
+
+### 2.2 파일 변경 목록
+| 파일 | 변경 유형 | 라인 수 |
+|------|----------|--------|
+| `functions/src/app/index.ts` | 수정 | ~20 (스케줄러 제거) |
+| `functions/src/app/scheduler.ts` | 신규 | ~40 |
+| `functions/src/providers/index.ts` | 수정 | ~40 (번들 분리) |
+| `functions/src/providers/discord/client.ts` | 수정 | +10 (REST 인스턴스) |
+| `functions/src/providers/discord/index.ts` | 수정 | +1 (rest export) |
+| `functions/src/providers/discord/utils/dmSender.ts` | 수정 | ~80 (2-step REST) |
+| `functions/src/crawlers/schedulers/base/BaseScheduler.ts` | 수정 | ~50 (runOnce 추출) |
+| `functions/src/crawlers/schedulers/RecruitScheduler.ts` | 수정 | ~5 (crawlAndDiff 호출) |
+| `functions/src/crawlers/schedulers/SchedulerManager.ts` | 수정 | ~10 (runRecruitOnce) |
+| `functions/src/events/bus/EventBus.ts` | 수정 | +10 (emitEventAndSettle) |
+| `functions/src/events/bus/utils/emitRecruitChangedEvent.ts` | 신규 | ~25 |
+| `functions/src/events/bus/index.ts` | 수정 | +1 (export) |
+| `functions/src/services/recruitService.ts` | 수정 | ~50 (crawlAndDiff + emit 배선) |
+| `functions/src/services/recruitCacheService.ts` | 수정 | ~15 (반환값 확장 + emit 제거) |
+| `functions/src/services/notificationService.ts` | 수정 | ~5 (emitEventAndSettle) |
+| `functions/src/providers/redis/manager/redisManager.ts` | 수정 | ~20 (분산 락) |
+
+**총 코드 라인**: ~440 lines (신규+수정)
+
+---
+
+## 3. 갭 분석 이력
+
+### 3.1 분석 결과 요약
+| 분석 회차 | 매치율 | 갭 수 | 조치 |
+|----------|--------|-------|------|
+| 1차 (2026-08-05) | 100.0% | 0 | 완료 (정적·로컬 한정) |
+
+### 3.2 주요 갭 해결 내역
+
+| 갭 | 원인 | 해결 방법 |
+|----|------|----------|
+| 런타임 분리 시 provider 배선 혼동 | 단일 부트스트랩에서 gateway/함수 구분 미명확 | `initGatewayProviders` / `initFunctionProviders` 번들 분리 + 시그니처 정의 |
+| onSchedule 호출 주체/타이밍 불명확 | 기존 setTimeout 루프 vs serverless cadence | `app/scheduler.ts` 신규 + `runOnce()` 단일 tick 추출 + `onSchedule("every 4 hours")` |
+| 서버리스 tick 이중 CPU 동결 위험 | 비동기 리스너 detach → in-flight DM 미완료 | `emitEventAndSettle` additive + Hop1·Hop2 promise 체인 연결 |
+| 캐시 TTL 무한 → 크롤 미발화 | 3-tier 읽기가 canonical Firestore doc 항상 히트 | `crawlAndDiff(mode)` 신설 + 3-tier 우회·강제 크롤 |
+| DM 발송 gateway 로그인 의존 | REST 토큰 주입과 ClientReady 빗장 강결합 | 2-step REST + `initDiscordRest()` 분리 + `getDiscordReady` 제거 |
+| Redis hash diff 동시성 경합 | 사용자 백업·스케줄러 강제 크롤 같은 hashstore 공유 | Redis 분산 락(`SET NX PX` + Lua CAS) + 60s TTL |
+
+---
+
+## 4. 검토 사항
+
+**참고 문서**: [review-process.md](../../.claude/rules/review-process.md)
+
+> ⚠️ 피드백 수신 시 즉시 반영하지 않음
+> 수정 계획 제시 → 사용자 승인 → 진행
+
+### 4.1 코드 리뷰
+- [x] 핵심 로직 구현 확인 — 런타임 분리·onSchedule·crawlAndDiff 3건 확정
+- [x] 타입 안전성 확인 — TypeScript strict mode, `emitEventAndSettle<T>`, `DmPayload`/`DmSendResult` 불변
+- [x] 에러 처리 확인 — provider throw 금지(결과 흡수), dmSender 계약 유지, 핸들러 try-catch
+- [x] 계약 불변성 확인 — `DmPayload`/`DmSendResult` 시그니처 100%, `getRecruitList` 본문 미수정, `onInteraction` 무변경
+
+### 4.2 기능 테스트
+
+#### 정적 검증 (TypeScript)
+- [x] `npx tsc --noEmit` **exit 0** (에러 0)
+
+#### 로컬 DUMMY E2E (기능 테스트) — `RUN_SCHEDULER_ONCE=true`
+
+아래 5개 항목을 Claude(C) / 사용자(U) 담당으로 분류해 검증했습니다. (design §2.3·2.2 0단계 절차 준수)
+
+| # | 항목 | 담당 | 결과 | 근거 / 검증 방법 |
+|---|------|------|------|-----------------|
+| R1 | slim 부트 (Function 프로세스는 REST 전용·gateway 로그인 미호출) | Claude | ✅ PASS | 로그: `Function providers initialized (REST only).` + `EventBus #2` 리스너 정확히 2개 등록(`RECRUIT_CHANGED`, `NOTIFICATION_SEND`), gateway 로그인 로그(`"Client ready"`) 없음, 스케줄러 크롤·DM 미발화(bootup 로그만) |
+| R2 | 로컬 DUMMY tick 완주 (crawl→diff→발화 직전 완결) | Claude | ✅ PASS | env `RUN_SCHEDULER_ONCE=true STOP_BEFORE_DM=true`로 tick 1회 실행, 예외 0. 첫 실행은 기준선 부재로 `RECRUIT_CHANGED` 미발행(first-seed, `Work completed 70ms`); 기준선 조작으로 diff 강제 시 `RECRUIT_CHANGED` 발행·알림 경로 완주(아래 §R2 diff 3케이스). 실 DM 0건(`DM 발송 성공` 로그 0), 락 획득·해제 후 Redis 잔존 락 nil |
+| R3 | Redis 분산 락 정합성 (정상 run: 획득·해제, 락 점유 상태: 스킵+로그) | Claude | ✅ PASS | (1) 정상 run: tick이 `SET NX PX 60000`으로 락 획득 후 diff·persist·emit 진입, `finally`의 Lua CAS로 해제 → 실행 후 락 키 재조회 nil. (2) 경합: 락을 수동 점유(`redis-cli set lock:recruit:crawlAndDiff … NX PX 30000`)한 상태로 tick 실행 → `"crawlAndDiff 락 획득 실패 — 다른 크롤 진행 중, 스킵"` 경고 후 크롤 로직 미진입(`Work completed 7ms`), 이후 수동 락 해제 |
+| R4 | 실제 DM 전송 (Discord 봇 상시 기동 + 실 구독자 1명 수신) | 사용자 | ⏸️ 이월(Phase 1.10) | 봇 상시 기동·실 CRAWL(`recruitMode: CRAWL`) 활성화 필요 → 범위 밖. 로컬에서는 STOP_BEFORE_DM 또는 대상자 0으로 검증 안전 격리. |
+| R5 | onSchedule 실발화 (Cloud Scheduler 4h 주기 배포·실행) | 사용자 | ⏸️ 이월(Phase 1.10) | 프로덕션 배포·Cloud Scheduler 프로비저닝 필요 → 범위 밖 |
+
+#### R2 추가 검증: diff 3 케이스 (모두 PASS, 실 DM 0건)
+
+DUMMY 크롤은 항상 동일한 9건 공고 반환 → **Redis 기준선 조작으로 각 케이스 강제**:
+
+**케이스 1: added (추가)**
+- 기준선(`recruit:hash:city:all`)에서 HDEL로 id 2건 제거 → 필드 7 → 9개 크롤 대비 2개 신규
+- diff 결과: `{ added: 2, ... }`
+- 이벤트 발행: ✅ `RECRUIT_CHANGED` 발행 확인 (Work completed 143ms). 알림 핸들러 진입했으나 구독자 지역 미매칭 → `NOTIFICATION_SEND` 미발행, 실 DM 0
+
+**케이스 2: updated (변경)**
+- 기준선에서 id 1건 해시값 변조 (예: score 변경)
+- 같은 id, 다른 hash 비교
+- diff 결과: `{ updated: 1, ... }`
+- 이벤트 발행: ✅ `RECRUIT_CHANGED` 발행 확인 (Work completed 140ms). 알림 핸들러 진입했으나 구독자 지역 미매칭 → `NOTIFICATION_SEND` 미발행, 실 DM 0
+
+**케이스 3: deleted (삭제)**
+- 유령 id 999 주입 후 크롤→diff: 유령 공고 9건 크롤에 없음 → `deletedIds: [999]`
+- diff 결과: `{ deleted: 1, ... }`
+- **이벤트 발행 미진입** ✅ (설계 의도: `notificationService.targetJobs = added+updated` → deleted 제외)
+- 발송 루프 미진입 → 실 DM 0 (설계대로)
+- 각 실행 후 기준선 자가 복원(수정분 재저장/HDEL 반영 확인) ✅
+
+#### 검증 방법론 (요약)
+- **실 DM 부작용 차단**: 임시 env 게이트 (`STOP_BEFORE_DM`)를 `notificationService.ts`에 삽입 후 로컬 검증 완료 시 원복(working tree diff 없음) + rebuild. 프로덕션 코드에 미포함.
+- **활성 구독자 필터링**: 1명 구독자 존재하나 SELECTED 모드·지역 필터에서 DUMMY 더미(지역코드 미매칭) → 발송 루프 미진입 (DM 0의 이중 안전장치)
+
+### 4.3 문서화
+- [x] JSDoc 주석 확인 — `runOnce`/`crawlAndDiff`/`emitEventAndSettle`/`initFunctionProviders`/`acquireLock`/`releaseLock` 신규 public API 주석 완료
+- [x] 관련 문서 업데이트 — design.md (상세 설계) / analysis.md (갭 분석) 완성
+
+---
+
+## 5. 피드백 반영 내역
+
+실시간 review가 없었으므로 기록 없음. 사용자 피드백 수신 시 아래 템플릿으로 반영:
+
+<!-- ### [Revision 1] {{date}} - {{제목}}
+**피드백 내용**:
+**수정 계획**:
+**승인 상태**: 대기 중 / 승인됨
+**수정 결과**: -->
+
+---
+
+## 6. Process Improvement
+
+### 6.1 잘된 점
+- **설계 게이트 명확화**: plan의 리스크 R1(`§1 런타임 결정 강결합`)을 do 진입 전 design §1에서 고정·승인으로 진행 순서 탁명화 — 후속 #2~#5가 명확한 구현 경로를 따름
+- **계약 중심 설계**: `DmPayload`/`DmSendResult`/`getRecruitList` 3-tier 계약 불변을 설계서에 명시 → 구현 범위 슈링크 가능
+- **로컬 검증 방식 (1.9 재사용)**: DUMMY 크롤 + 기준선 조작 + env 게이팅으로 실 DM·CRAWL 미활성화 상태에서도 **파이프라인 정상 작동 확인** — 프로덕션 배포 전 confidence 향상
+- **단일 tick 분리 (테스트 용이)**: `runOnce()` 추출로 로컬 unit test / `onSchedule` wrap / 로컬 DUMMY E2E 세 경로가 동일 로직 검증 가능
+- **갭 분석 카테고리화**: Structural/Functional/Contract 3축 분류로 매치율 산출의 의미 명확화 — 각 축이 아키텍처·기능·외부 인터페이스에 대응
+
+### 6.2 개선할 점
+- **락 TTL 실측 이월**: 설계에서 "60s 고정"으로 가정했으나, 실제 구독자 다수/느린 크롤 시 `emitEventAndSettle` 대기 시간 미측정 → 1.10 E2E에서 락 범위 축소/TTL 재산정 필요. 구독자별 DM 순차 await 블로킹 비용도 동시 실측 권장 (report 이슈 #1)
+- **공용 emit 헬퍼 로직 중복**: `emitRecruitChangedEvent` 내부 `.then(CHANGED && emit).catch(warn)` 래핑이 `getRecruitList` 두 백업 호출부에서 복제 → private 헬퍼 추상화 추천 (분석 #4 Info)
+- **로컬 실행 모드 진입점 비명확**: `RUN_SCHEDULER_ONCE=true` env 게이팅은 gateway/함수 프로세스 부트스트랩을 다시 읽어야 이해 가능 → 주석/로그 강화 또는 진입점 파일 최상단에 "로컬 모드" 콕콕 명기 권장
+- **Firestore 트리거 계약 미배선**: §1.1 "DB-as-bus" 방침만 명시되고 실제 Firestore 컬렉션 설계/리스너 코드는 Phase 2.1/2.2 이월 — 앞으로의 크로스-프로세스 확장 시 이 설계 명시사항을 재확인 필수 (design §1.1 링크 강화 권장)
+- **코드 정리 미완료**: 이슈 #5(데드코드 `initializeSchedulers`) / #8(import 정렬) 미반영 → 다음 iterate/커밋에서 housekeeping 일괄 처리 권장 (분석 Info 7건)
+
+### 6.3 다음 Phase 제안
+
+| 제안 | 관련 Phase | 우선순위 |
+|------|-----------|---------|
+| onSchedule 실발화·REST DM 실전송·프로덕션 E2E | 1.10 | ⭐⭐⭐ (P0) |
+| 실 CRAWL 활성화 (`recruitMode: CRAWL`), 실배포 gateway (Cloud Run) | 1.10 | ⭐⭐⭐ (P0) |
+| `crawlService.ts:28` DUMMY 버그(#6) 수정·테스트 | 1.10 | ⭐⭐ (P1) |
+| Firestore 크로스-프로세스 트리거 실배선 (에러 로그 발행 등) | 2.1/2.2 | ⭐⭐ (P1) |
+| 락 범위 최적화/TTL 동적 재산정 (1.10 E2E 실측 후) | iterate | ⭐ (P2) |
+| 공용 emit 헬퍼 중복 제거·코드 정리 (housekeeping) | iterate | ⭐ (P2) |
+
+---
+
+## 7. 다음 단계
+
+1. [ ] 사용자 피드백 확인 및 승인 (본 report 검토)
+2. [ ] `/pdca archive 1.13` 실행 (문서 → `docs/archive/phase-1-13/` 이동)
+3. [ ] `/pdca cleanup` 실행 (pdca-status.json 히스토리 정리 + pdca-memory.json 초기화)
+4. [ ] Git 커밋(논리 단위) + push + PR 생성 (base dev)
+   - `feat(phase-1-13): 프로덕션 런타임 & 스케줄러 트리거 재설계` (기능 코드)
+   - `chore: archive phase-1-13 + pdca bookkeeping` (문서·상태 이동)
+5. [ ] PR 머지 → dev 동기화 → `/pdca next`
+
+### 🔍 최종 검증 요약
+- **매치율**: 100.0% (Structural 13/13 + Functional 10/10 + Contract 8/8)
+- **Critical 이슈**: 0건
+- **정적 통과**: ✅ TypeScript `exit 0`
+- **로컬 DUMMY E2E**: ✅ 5개 항목 중 Claude 담당 3개(R1~R3) PASS, 사용자 담당 2개(R4·R5) Phase 1.10 이월
+- **범위 명시**: 코드 + 정적/로컬 검증 한정 (실배포·실 CRAWL·프로덕션 E2E → Phase 1.10)
+
+---
+
+*작성일: 2026-08-07*
+*참고: docs/phase-1-13/{01-plan.md, 02-design.md, 03-analysis.md}*

--- a/functions/src/app/index.ts
+++ b/functions/src/app/index.ts
@@ -4,34 +4,25 @@ import "@/common/utils/systemLogger";
 import { registerGlobalErrorHandlers } from "./registerGlobalErrorHandlers";
 import { initExpress } from "./express";
 import { firebaseDeploy } from "@/providers/firebase";
-import { initializeProviders } from "@/providers";
+import { initGatewayProviders } from "@/providers";
 import { registerAllEventHandlers } from "@/events";
-import { initializeSchedulers, setupGracefulShutdown } from "@/crawlers";
-import { CRAWL_MODE } from "@/common/constants";
 
 // 최후의 거름망(A): init 중 발생하는 미처리 rejection/예외도 잡도록 가장 먼저 등록한다.
 registerGlobalErrorHandlers();
 
 // 모듈 로드 시점에 즉시 init 시작 (로컬 emulator 부팅 / 프로덕션 cold start).
-// initializeProviders()는 메모이즈되어 있어 미들웨어가 다시 호출해도
+// initGatewayProviders()는 메모이즈되어 있어 미들웨어가 다시 호출해도
 // 같은 promise를 await할 뿐 중복 실행되지 않는다.
 //
-// provider init 완료 후 알림 파이프라인을 연결한다 (Phase 1.9 — 로컬 wiring):
-//   1) EventBus 핸들러 등록 (멱등 가드 내장) — 없으면 RECRUIT_NEW에 구독자 0
-//   2) RecruitScheduler 시작 (DUMMY, Proxy off→1.10) — 첫 크롤이 자동 E2E
-//   3) graceful shutdown 연결
-// 스케줄러는 Discord ready로 막지 않는다(C안) — DM 발송 직전 dmSender에서만 대기.
-initializeProviders()
+// gateway 프로세스는 인터랙션 수신만 담당하며 스케줄러를 시작하지 않는다(C안).
+// 크롤·알림 tick은 함수 프로세스(app/scheduler.ts onSchedule)가 담당한다.
+// provider init 완료 후 EventBus 핸들러만 등록한다(멱등 가드 내장).
+initGatewayProviders()
   .then(() => {
     registerAllEventHandlers();
-    const manager = initializeSchedulers({
-      recruitMode: CRAWL_MODE.DUMMY,
-      enableProxy: false,
-    });
-    setupGracefulShutdown(manager);
   })
   .catch((error) => {
-    globalLogger.error("Eager provider initialization / pipeline wiring failed:", error);
+    globalLogger.error("Eager gateway provider initialization failed:", error);
   });
 
 const expressApp = initExpress();

--- a/functions/src/app/scheduler.ts
+++ b/functions/src/app/scheduler.ts
@@ -1,0 +1,29 @@
+import dotenv from "dotenv";
+dotenv.config();
+import "@/common/utils/systemLogger";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { registerGlobalErrorHandlers } from "./registerGlobalErrorHandlers";
+import { initFunctionProviders } from "@/providers";
+import { registerAllEventHandlers } from "@/events";
+import { SchedulerManager } from "@/crawlers";
+import { CRAWL_MODE } from "@/common/constants";
+
+// 최후의 거름망(A): init 중 발생하는 미처리 rejection/예외도 잡도록 가장 먼저 등록한다.
+registerGlobalErrorHandlers();
+
+// 함수 프로세스 부트스트랩: REST 전용 provider init 후 EventBus 핸들러 등록.
+// 메모이즈된 ready promise를 각 트리거가 await한다.
+const ready = initFunctionProviders().then(() => registerAllEventHandlers());
+
+/** 프로덕션 크롤 트리거 (코드만 — 실발화·실 CRAWL·실배포는 Phase 1.10). */
+export const recruitSchedule = onSchedule("every 4 hours", async () => {
+  await ready;
+  await SchedulerManager.getInstance().runRecruitOnce(CRAWL_MODE.CRAWL);
+});
+
+// 로컬 DUMMY E2E (1.9 auto-E2E 대체) — env 게이팅. 실행: RUN_SCHEDULER_ONCE=true
+if (process.env.RUN_SCHEDULER_ONCE === "true") {
+  ready
+    .then(() => SchedulerManager.getInstance().runRecruitOnce(CRAWL_MODE.DUMMY))
+    .catch((e) => globalLogger.error("로컬 스케줄러 1회 실행 실패:", e));
+}

--- a/functions/src/claude.md
+++ b/functions/src/claude.md
@@ -67,7 +67,7 @@ src/
 
 **주요 서비스**:
 - recruitService.ts (3-tier 캐싱)
-- **recruitCacheService.ts** 🆕 (Phase 1.3: RECRUIT_NEW 이벤트 발행)
+- **recruitCacheService.ts** 🆕 (Phase 1.3: RECRUIT_CHANGED 이벤트 발행)
 - notificationService.ts (알림 발송)
 - aiService.ts (AI 요약 - Phase 4)
 
@@ -110,17 +110,17 @@ src/
 2. **이벤트 기반 통신 (Phase 1.1+)**:
    ```typescript
    // 이벤트 발행 (services 계층)
-   eventBus.emitEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, {
+   eventBus.emitEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, {
      timestamp: Date.now(),
      source: "RecruitCacheService",
      addedJobs, updatedJobs, deletedIds
    });
 
    // 이벤트 구독 (listeners 계층)
-   eventBus.on(EventType.RECRUIT_NEW, handleNewRecruits);
+   eventBus.on(EventType.RECRUIT_CHANGED, handleNewRecruits);
    ```
 
-   **Phase 1.3 구현**: recruitCacheService에서 캐시 변경 시 RECRUIT_NEW 이벤트 발행
+   **Phase 1.3 구현**: recruitCacheService에서 캐시 변경 시 RECRUIT_CHANGED 이벤트 발행
 
 3. **의존성 규칙**:
    - ✅ 상위 → 하위만 참조

--- a/functions/src/crawlers/schedulers/RecruitScheduler.ts
+++ b/functions/src/crawlers/schedulers/RecruitScheduler.ts
@@ -36,13 +36,13 @@ export class RecruitScheduler extends BaseScheduler {
         `[${this.config.name}] 🔍 Crawling started (Mode: ${this.mode})...`
       );
 
-      const { data: recruitData } = await this.recruitService.getRecruitList(this.mode);
+      const diff = await this.recruitService.crawlAndDiff(this.mode);
 
       const endTime = new Date();
       const durationMs = endTime.getTime() - startTime.getTime();
 
-      const totalCount = recruitData?.length || 0;
-      const message = `Collected ${totalCount} recruitment data`;
+      const totalCount = diff.addedJobs.length + diff.updatedJobs.length;
+      const message = `Collected ${totalCount} recruitment data (added/updated)`;
 
       return {
         success: true,

--- a/functions/src/crawlers/schedulers/SchedulerManager.ts
+++ b/functions/src/crawlers/schedulers/SchedulerManager.ts
@@ -2,7 +2,7 @@ import "@/common/utils/systemLogger";
 import { RecruitScheduler } from "./RecruitScheduler";
 import { ProxyScheduler } from "./ProxyScheduler";
 import { CRAWL_MODE } from "@/common/constants";
-import type { SchedulerStatus } from "./types";
+import type { SchedulerStatus, WorkResult } from "./types";
 import { BaseScheduler } from "./base/BaseScheduler";
 
 /**
@@ -39,6 +39,23 @@ export class SchedulerManager {
     }
 
     scheduler.startWork();
+  }
+
+  /**
+   * Recruit 스케줄러 단일 tick 실행 (서버리스 onSchedule 전용).
+   * setTimeout 재스케줄 루프를 시작하지 않고 runOnce()만 1회 실행한다.
+   * @param mode CRAWL_MODE (프로덕션=CRAWL, 로컬 E2E=DUMMY)
+   */
+  async runRecruitOnce(mode: CRAWL_MODE): Promise<WorkResult> {
+    let scheduler = this.schedulers.get("recruit") as RecruitScheduler;
+
+    if (!scheduler) {
+      scheduler = new RecruitScheduler(undefined, mode);
+      this.schedulers.set("recruit", scheduler);
+    }
+
+    scheduler.setMode(mode);
+    return scheduler.runOnce();
   }
 
   /**

--- a/functions/src/crawlers/schedulers/base/BaseScheduler.ts
+++ b/functions/src/crawlers/schedulers/base/BaseScheduler.ts
@@ -26,7 +26,8 @@ export abstract class BaseScheduler {
   protected abstract performWork(): Promise<WorkResult>;
 
   /**
-   * 스케줄러 시작
+   * 스케줄러 시작 (로컬 장기 실행 — setTimeout 재스케줄 루프).
+   * 서버리스(onSchedule)는 이 메서드 대신 runOnce()를 직접 호출한다.
    */
   startWork(): void {
     if (this.isRunning) {
@@ -37,18 +38,15 @@ export abstract class BaseScheduler {
     this.isRunning = true;
     globalLogger.info(`[${this.config.name}] ✅ Scheduler started.`);
 
-    this.scheduleNextWork().catch((error) => {
-      this.handleError(error);
-      this.scheduleNextWork(); // 재시도
-    });
+    void this.runOnce().finally(() => this.scheduleNextExecution());
   }
 
   /**
-   * 다음 작업 스케줄링
+   * 단일 tick 실행 — STARTED 발행 → performWork → COMPLETED/FAILED 발행.
+   * throw 없이 항상 WorkResult를 반환하며, 재스케줄(scheduleNextExecution)을 하지 않는다.
+   * 서버리스 onSchedule 및 startWork 루프가 공유하는 실행 단위.
    */
-  private async scheduleNextWork(): Promise<void> {
-    if (!this.isRunning) return;
-
+  async runOnce(): Promise<WorkResult> {
     const startTime = Date.now();
 
     // STARTED 이벤트 발행
@@ -82,8 +80,17 @@ export abstract class BaseScheduler {
       );
 
       this.logWorkCompletion(result);
-    } catch (error) {
+      return result;
+    } catch (thrown) {
       const durationMs = Date.now() - startTime;
+
+      // performWork가 던지는 객체는 WorkResult 유사 형태(error/message 포함) — 안전 변환
+      const err =
+        thrown instanceof Error
+          ? thrown
+          : (thrown as { error?: Error })?.error ??
+            new Error(String((thrown as { message?: string })?.message ?? thrown));
+      const message = (thrown as { message?: string })?.message ?? err.message;
 
       // FAILED 이벤트 발행
       eventBus.emitEvent<RecruitCrawlFailedEvent>(
@@ -92,20 +99,26 @@ export abstract class BaseScheduler {
           timestamp: Date.now(),
           source: "BaseScheduler",
           schedulerName: this.config.name,
-          error: error as Error,
+          error: err,
           duration: durationMs,
         }
       );
 
-      this.handleError(error as Error);
-    }
+      this.handleError(err);
 
-    // 다음 실행 스케줄링
-    this.scheduleNextExecution();
+      return {
+        success: false,
+        startTime: new Date(startTime),
+        endTime: new Date(),
+        durationMs,
+        error: err,
+        message: `[${this.config.name}] Work failed: ${message}`,
+      };
+    }
   }
 
   /**
-   * 다음 실행 스케줄링
+   * 다음 실행 스케줄링 (로컬 장기 실행 전용)
    */
   private scheduleNextExecution(): void {
     if (!this.isRunning) return;
@@ -117,7 +130,8 @@ export abstract class BaseScheduler {
     this.nextRunTime = new Date(now + delay);
 
     setTimeout(() => {
-      this.scheduleNextWork();
+      if (!this.isRunning) return;
+      void this.runOnce().finally(() => this.scheduleNextExecution());
     }, delay);
   }
 

--- a/functions/src/events/bus/EventBus.ts
+++ b/functions/src/events/bus/EventBus.ts
@@ -13,7 +13,7 @@ import { eventLogger } from './utils/eventLogger';
  * import { eventBus, EventType } from '@/events';
  *
  * // 이벤트 발행
- * eventBus.emitEvent(EventType.RECRUIT_NEW, {
+ * eventBus.emitEvent(EventType.RECRUIT_CHANGED, {
  *   timestamp: Date.now(),
  *   addedJobs: [],
  *   updatedJobs: [],
@@ -21,7 +21,7 @@ import { eventLogger } from './utils/eventLogger';
  * });
  *
  * // 이벤트 구독
- * eventBus.onEvent(EventType.RECRUIT_NEW, async (payload) => {
+ * eventBus.onEvent(EventType.RECRUIT_CHANGED, async (payload) => {
  *   console.log('New recruits:', payload);
  * });
  * ```
@@ -59,7 +59,7 @@ export class EventBus extends EventEmitter {
    *
    * @example
    * ```typescript
-   * eventBus.emitEvent(EventType.RECRUIT_NEW, {
+   * eventBus.emitEvent(EventType.RECRUIT_CHANGED, {
    *   timestamp: Date.now(),
    *   addedJobs: [job1, job2],
    *   updatedJobs: [],
@@ -78,6 +78,21 @@ export class EventBus extends EventEmitter {
   }
 
   /**
+   * 리스너들의 반환 promise를 수집해 모두 settle될 때까지 await한다.
+   * 서버리스 tick이 in-flight 핸들러(DM 발송 등)를 자르지 않도록 완결 보장.
+   * 기존 emitEvent(fire-and-forget)와 별개 — 틱 완결이 필요한 경로에서만 사용.
+   *
+   * @param event - 이벤트 타입 (EventType enum)
+   * @param payload - 이벤트 페이로드
+   */
+  async emitEventAndSettle<T>(event: EventType, payload: T): Promise<void> {
+    const listeners = this.listeners(event) as Array<(p: T) => void | Promise<void>>;
+    const hasListeners = listeners.length > 0;
+    await Promise.allSettled(listeners.map((l) => l(payload)));
+    eventLogger.emitted(event, hasListeners);
+  }
+
+  /**
    * 타입 안전성을 제공하는 이벤트 구독 메서드
    *
    * @param event - 구독할 이벤트 타입 (EventType enum)
@@ -86,7 +101,7 @@ export class EventBus extends EventEmitter {
    *
    * @example
    * ```typescript
-   * eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, async (payload) => {
+   * eventBus.onEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, async (payload) => {
    *   await notificationService.notifyNewRecruits(payload);
    * });
    * ```
@@ -128,9 +143,9 @@ export class EventBus extends EventEmitter {
    * @example
    * ```typescript
    * const handler = (payload) => console.log(payload);
-   * eventBus.onEvent(EventType.RECRUIT_NEW, handler);
+   * eventBus.onEvent(EventType.RECRUIT_CHANGED, handler);
    * // 나중에 제거
-   * eventBus.offEvent(EventType.RECRUIT_NEW, handler);
+   * eventBus.offEvent(EventType.RECRUIT_CHANGED, handler);
    * ```
    */
   offEvent<T>(event: EventType, listener: (payload: T) => void | Promise<void>): this {
@@ -150,7 +165,7 @@ export class EventBus extends EventEmitter {
    *
    * @example
    * ```typescript
-   * eventBus.removeAllListenersForEvent(EventType.RECRUIT_NEW);
+   * eventBus.removeAllListenersForEvent(EventType.RECRUIT_CHANGED);
    * ```
    */
   removeAllListenersForEvent(event: EventType): this {
@@ -170,7 +185,7 @@ export class EventBus extends EventEmitter {
    *
    * @example
    * ```typescript
-   * const count = eventBus.listenerCountForEvent(EventType.RECRUIT_NEW);
+   * const count = eventBus.listenerCountForEvent(EventType.RECRUIT_CHANGED);
    * console.log(`Listeners: ${count}`);
    * ```
    */
@@ -186,7 +201,7 @@ export class EventBus extends EventEmitter {
  * ```typescript
  * import { eventBus, EventType } from '@/eventBus';
  *
- * eventBus.emitEvent(EventType.RECRUIT_NEW, data);
+ * eventBus.emitEvent(EventType.RECRUIT_CHANGED, data);
  * ```
  */
 export const eventBus = EventBus.getInstance();

--- a/functions/src/events/bus/__test__/EventBus.test.ts
+++ b/functions/src/events/bus/__test__/EventBus.test.ts
@@ -7,7 +7,7 @@
  * - 타입 추론이 올바르게 작동
  */
 
-import { eventBus, EventType, RecruitNewEvent } from '../index';
+import { eventBus, EventType, RecruitChangedEvent } from '../index';
 
 /**
  * 간단한 테스트 함수
@@ -23,19 +23,19 @@ export async function testEventBus(): Promise<void> {
   // 2. 이벤트 리스너 등록
   console.log('\n✓ 테스트 2: 이벤트 리스너 등록');
   let eventReceived = false;
-  let receivedPayload: RecruitNewEvent | null = null;
+  let receivedPayload: RecruitChangedEvent | null = null;
 
-  eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, (payload) => {
+  eventBus.onEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, (payload) => {
     console.log('  이벤트 수신됨!');
     eventReceived = true;
     receivedPayload = payload;
   });
 
-  console.log(`  리스너 등록 완료 (${EventType.RECRUIT_NEW})`);
+  console.log(`  리스너 등록 완료 (${EventType.RECRUIT_CHANGED})`);
 
   // 3. 이벤트 발행
   console.log('\n✓ 테스트 3: 이벤트 발행');
-  const testPayload: RecruitNewEvent = {
+  const testPayload: RecruitChangedEvent = {
     timestamp: Date.now(),
     source: 'test',
     addedJobs: [
@@ -54,7 +54,7 @@ export async function testEventBus(): Promise<void> {
     deletedIds: [],
   };
 
-  const emitResult = eventBus.emitEvent(EventType.RECRUIT_NEW, testPayload);
+  const emitResult = eventBus.emitEvent(EventType.RECRUIT_CHANGED, testPayload);
   console.log(`  이벤트 발행 결과: ${emitResult ? '성공' : '실패'}`);
 
   // 4. 이벤트 수신 확인
@@ -70,7 +70,7 @@ export async function testEventBus(): Promise<void> {
 
   // 5. 리스너 수 확인
   console.log('\n✓ 테스트 5: 리스너 수 확인');
-  const listenerCount = eventBus.listenerCountForEvent(EventType.RECRUIT_NEW);
+  const listenerCount = eventBus.listenerCountForEvent(EventType.RECRUIT_CHANGED);
   console.log(`  현재 리스너 수: ${listenerCount}`);
 
   // 6. 타입 안전성 테스트

--- a/functions/src/events/bus/claude.md
+++ b/functions/src/events/bus/claude.md
@@ -54,7 +54,7 @@ export const eventBus = EventBus.getInstance();
 export enum EventType {
   // Recruit Events
   CRAWL_STARTED = 'recruit.crawl.started',
-  RECRUIT_NEW = 'recruit.new',
+  RECRUIT_CHANGED = 'recruit:changed',
 
   // Notification Events
   NOTIFICATION_SEND = 'notification.send',
@@ -77,8 +77,8 @@ export interface BaseEvent {
   source: string;
 }
 
-export interface RecruitNewEvent extends BaseEvent {
-  type: EventType.RECRUIT_NEW;
+export interface RecruitChangedEvent extends BaseEvent {
+  type: EventType.RECRUIT_CHANGED;
   data: {
     addedJobs: Job[];
     updatedJobs: Job[];
@@ -94,7 +94,7 @@ export interface RecruitNewEvent extends BaseEvent {
 
 ```
 handlers/
-├── NotificationEventHandler.ts  # recruit.new → 알림 발송
+├── NotificationEventHandler.ts  # recruit:changed → 알림 발송
 ├── ErrorEventHandler.ts          # error.critical → 관리자 알림
 └── index.ts                      # 전체 핸들러 export
 ```
@@ -102,11 +102,11 @@ handlers/
 **예시: NotificationEventHandler.ts**
 ```typescript
 import { eventBus } from '../EventBus';
-import { EventType, RecruitNewEvent } from '../types';
+import { EventType, RecruitChangedEvent } from '../types';
 import { notificationService } from '@/services/notificationService';
 
 export function registerNotificationHandlers() {
-  eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, async (payload) => {
+  eventBus.onEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, async (payload) => {
     await notificationService.notifyNewRecruits(payload.data);
   });
 }
@@ -143,12 +143,12 @@ registerAllEventHandlers();  // 모듈 레벨에서 1회만 실행
 ### 1. 이벤트 루프 방지
 ```typescript
 // ❌ 무한 루프
-eventBus.on('recruit.new', (payload) => {
-  eventBus.emit('recruit.new', payload);  // 재발행!
+eventBus.on('recruit:changed', (payload) => {
+  eventBus.emit('recruit:changed', payload);  // 재발행!
 });
 
 // ✅ 다른 이벤트 발행
-eventBus.on('recruit.new', (payload) => {
+eventBus.on('recruit:changed', (payload) => {
   eventBus.emit('notification.send', { ... });
 });
 ```
@@ -156,7 +156,7 @@ eventBus.on('recruit.new', (payload) => {
 ### 2. 에러 처리
 ```typescript
 // ✅ 모든 핸들러는 try-catch
-eventBus.on('recruit.new', async (payload) => {
+eventBus.on('recruit:changed', async (payload) => {
   try {
     await processRecruits(payload);
   } catch (error) {

--- a/functions/src/events/bus/handlers/NotificationEventHandler.ts
+++ b/functions/src/events/bus/handlers/NotificationEventHandler.ts
@@ -1,24 +1,24 @@
 import "@/common/utils/systemLogger"; // globalLogger 전역 등록
 import { eventBus, EventType } from "@/events/bus";
-import type { RecruitNewEvent } from "@/events/bus";
+import type { RecruitChangedEvent } from "@/events/bus";
 import { notificationService } from "@/services/notificationService";
 
 /**
  * 알림 이벤트 핸들러 등록 (Phase 1.7)
  *
- * `RECRUIT_NEW` → `notificationService.notifyNewRecruits` 를 연결한다.
+ * `RECRUIT_CHANGED` → `notificationService.notifyNewRecruits` 를 연결한다.
  *
  * @remarks 핸들러 내부 try-catch로 EventBus 안정성을 확보한다(emitter로
  *   재throw 금지) — `recruitCacheService`의 발행부 try-catch 패턴과 대칭.
  *   `registerAllEventHandlers()` 자체의 startup 호출은 Phase 1.9에 위임.
  */
 export function registerNotificationHandlers(): void {
-  eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, async (payload) => {
+  eventBus.onEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, async (payload) => {
     try {
       await notificationService.notifyNewRecruits(payload);
     } catch (error) {
       globalLogger.error("알림 핸들러 처리 실패", error as Error, {
-        event: EventType.RECRUIT_NEW,
+        event: EventType.RECRUIT_CHANGED,
         source: "NotificationEventHandler",
       });
     }

--- a/functions/src/events/bus/index.ts
+++ b/functions/src/events/bus/index.ts
@@ -19,3 +19,4 @@ export {
   areHandlersRegistered,
   resetHandlerRegistration,
 } from './utils/registerEventHandlers';
+export { emitRecruitChangedEvent } from './utils/emitRecruitChangedEvent';

--- a/functions/src/events/bus/types.ts
+++ b/functions/src/events/bus/types.ts
@@ -18,7 +18,7 @@ export enum EventType {
   RECRUIT_CRAWL_STARTED = "recruit:crawl:started",
   RECRUIT_CRAWL_COMPLETED = "recruit:crawl:completed",
   RECRUIT_CRAWL_FAILED = "recruit:crawl:failed",
-  RECRUIT_NEW = "recruit:new",
+  RECRUIT_CHANGED = "recruit:changed",
   RECRUIT_REQUESTED = "recruit:requested",
   RECRUIT_REQUEST_COMPLETED = "recruit:request:completed",
 
@@ -74,7 +74,7 @@ export interface RecruitCrawlFailedEvent extends BaseEvent {
  *
  * @description JobDiffResult (공고 변경 사항)를 이벤트 페이로드로 감싸는 인터페이스
  */
-export interface RecruitNewEvent extends BaseEvent, JobDiffResult {}
+export interface RecruitChangedEvent extends BaseEvent, JobDiffResult {}
 
 // 사용자 공고 요청 시작 이벤트
 export interface RecruitRequestedEvent extends BaseEvent {
@@ -174,7 +174,7 @@ export interface EventPayloadMap {
   [EventType.RECRUIT_CRAWL_STARTED]: RecruitCrawlStartedEvent;
   [EventType.RECRUIT_CRAWL_COMPLETED]: RecruitCrawlCompletedEvent;
   [EventType.RECRUIT_CRAWL_FAILED]: RecruitCrawlFailedEvent;
-  [EventType.RECRUIT_NEW]: RecruitNewEvent;
+  [EventType.RECRUIT_CHANGED]: RecruitChangedEvent;
   [EventType.RECRUIT_REQUESTED]: RecruitRequestedEvent;
   [EventType.RECRUIT_REQUEST_COMPLETED]: RecruitRequestCompletedEvent;
 

--- a/functions/src/events/bus/utils/emitRecruitChangedEvent.ts
+++ b/functions/src/events/bus/utils/emitRecruitChangedEvent.ts
@@ -1,0 +1,31 @@
+import "@/common/utils/systemLogger";
+import { eventBus } from "../EventBus";
+import { EventType } from "../types";
+import type { RecruitChangedEvent } from "../types";
+import type { JobDiffResult } from "@/common/types/job.d";
+
+/**
+ * RECRUIT_CHANGED 발행 공용 헬퍼 — 두 발행부(사용자 백업 write·스케줄러 crawlAndDiff)가
+ * 동일 payload 조립 + try-catch 방어(발행 실패가 캐시 성공을 막지 않음)를 공유.
+ * CHANGED gating은 호출 측이 담당한다.
+ *
+ * @param diff 공고 변경 사항 (added/updated/deleted)
+ * @param source 발행 출처 식별 문자열
+ * @param opts.awaitSettle true면 emitEventAndSettle await(틱 완결), false면 fire-and-forget.
+ */
+export async function emitRecruitChangedEvent(
+  diff: JobDiffResult,
+  source: string,
+  opts: { awaitSettle: boolean }
+): Promise<void> {
+  const payload: RecruitChangedEvent = { timestamp: Date.now(), source, ...diff };
+  try {
+    if (opts.awaitSettle) {
+      await eventBus.emitEventAndSettle<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, payload);
+    } else {
+      eventBus.emitEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, payload);
+    }
+  } catch (error) {
+    globalLogger.error("RECRUIT_CHANGED 이벤트 발행 실패", error as Error, { source });
+  }
+}

--- a/functions/src/features/claude.md
+++ b/functions/src/features/claude.md
@@ -145,8 +145,8 @@ export class NotificationService {
   private readonly subscriptionStore = new SubscriptionStore();
 
   constructor() {
-    // recruit.new 이벤트 리스너 등록
-    eventBus.on('recruit.new', this.notifyNewRecruits);
+    // recruit:changed 이벤트 리스너 등록
+    eventBus.on('recruit:changed', this.notifyNewRecruits);
   }
 
   async notifyNewRecruits(data) {

--- a/functions/src/providers/discord/client.ts
+++ b/functions/src/providers/discord/client.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits } from "discord.js";
+import { Client, GatewayIntentBits, REST } from "discord.js";
 
 export const client = new Client({
   intents: [
@@ -7,3 +7,11 @@ export const client = new Client({
     GatewayIntentBits.MessageContent,
   ],
 });
+
+/** DM 발송 전용 REST 클라이언트 — gateway WS/login과 독립. 함수 프로세스가 사용. */
+export const rest = new REST({ version: "10" });
+
+/** REST 토큰 주입. 부트스트랩이 프로세스별로 호출(gateway 로그인과 무관). */
+export function initDiscordRest(): void {
+  rest.setToken(process.env.DISCORD_BOT_TOKEN!);
+}

--- a/functions/src/providers/discord/index.ts
+++ b/functions/src/providers/discord/index.ts
@@ -1,1 +1,2 @@
 export { initDiscordBot } from "./initDiscordBot";
+export { rest, initDiscordRest } from "./client";

--- a/functions/src/providers/discord/utils/dmSender.ts
+++ b/functions/src/providers/discord/utils/dmSender.ts
@@ -1,6 +1,6 @@
-import type { MessageCreateOptions } from "discord.js";
-import { client } from "@/providers/discord/client";
-import { getDiscordReady } from "@/providers/discord/discordReady";
+import type { APIEmbed, MessageCreateOptions } from "discord.js";
+import { Routes } from "discord.js";
+import { rest } from "@/providers/discord/client";
 import { providerLogger } from "@/common/utils/systemLogger";
 
 /**
@@ -89,6 +89,20 @@ function getRateLimitWaitMs(error: unknown): number | undefined {
 }
 
 /**
+ * DmPayload.embeds(빌더 가능)를 REST body용 APIEmbed[]로 정규화한다.
+ * 빌더(.toJSON 존재)면 toJSON(), 이미 API 객체면 통과. embeds 없으면 undefined.
+ * @remarks 계약 밖 내부 변환 — DmPayload 필드·의미 불변.
+ */
+function toApiEmbeds(embeds: DmPayload["embeds"]): APIEmbed[] | undefined {
+  if (!embeds) return undefined;
+  return embeds.map((e) =>
+    typeof (e as { toJSON?: unknown }).toJSON === "function"
+      ? (e as { toJSON(): APIEmbed }).toJSON()
+      : (e as APIEmbed)
+  );
+}
+
+/**
  * 지정한 사용자에게 알림 DM을 발송한다.
  *
  * 포맷 무관(embeds 기반) — 임베드는 호출 측이 빌더로 완성해 전달한다.
@@ -112,15 +126,18 @@ export async function sendNotificationDM(
   const startedAt = Date.now();
   let attempts = 0;
 
-  // ClientReady 전 client.users.fetch()는 실패한다 → 발송 직전 1회만 ready 빗장을 기다린다(C안).
-  // 루프 진입 전에 두어 재시도마다 재-await하지 않는다. 빗장은 leaf 모듈에서 직접 import(R3 순환 차단).
-  await getDiscordReady();
-
+  // REST 전용 경로 — gateway 로그인/ready 빗장 불필요. setToken만으로 호출 성립.
   while (attempts < MAX_ATTEMPTS) {
     attempts++;
     try {
-      const user = await client.users.fetch(userId);
-      await user.send({ embeds: payload.embeds, content: payload.content });
+      // 1) DM 채널 개설 — POST /users/@me/channels { recipient_id }
+      const dmChannel = (await rest.post(Routes.userChannels(), {
+        body: { recipient_id: userId },
+      })) as { id: string };
+      // 2) 메시지 전송 — POST /channels/{id}/messages
+      await rest.post(Routes.channelMessages(dmChannel.id), {
+        body: { embeds: toApiEmbeds(payload.embeds), content: payload.content },
+      });
 
       const durationMs = Date.now() - startedAt;
       providerLogger.info("DM 발송 성공", { userId, durationMs, attempts });

--- a/functions/src/providers/index.ts
+++ b/functions/src/providers/index.ts
@@ -1,15 +1,21 @@
-import { initDiscordBot } from "./discord";
+import "@/common/utils/systemLogger";
+import { initDiscordBot, initDiscordRest } from "./discord";
 import { initFirebaseApp } from "./firebase";
 import { initRedis } from "./redis";
 
 // 서버 종료 시 외부 서비스 연결 해제 설정 필요
 
-let initPromise: Promise<void> | null = null;
+let gatewayInitPromise: Promise<void> | null = null;
+let functionInitPromise: Promise<void> | null = null;
 
-export function initializeProviders(): Promise<void> {
-  if (initPromise) return initPromise;
+/**
+ * Gateway 프로세스: Firebase+Redis+Discord gateway(WS+login+ready 빗장).
+ * 인터랙션(슬래시 커맨드·버튼 등) 수신용. 메모이즈된다.
+ */
+export function initGatewayProviders(): Promise<void> {
+  if (gatewayInitPromise) return gatewayInitPromise;
 
-  initPromise = (async () => {
+  gatewayInitPromise = (async () => {
     await Promise.all([
       initFirebaseApp(),
       initRedis(),
@@ -17,9 +23,37 @@ export function initializeProviders(): Promise<void> {
     ]);
     globalLogger.info("All providers initialized successfully.");
   })().catch((error) => {
-    initPromise = null;
+    gatewayInitPromise = null;
     throw error;
   });
 
-  return initPromise;
+  return gatewayInitPromise;
 }
+
+/**
+ * 함수 프로세스: Firebase+Redis+Discord REST(login/ready 없음).
+ * onSchedule 크롤·알림용. 메모이즈된다.
+ */
+export function initFunctionProviders(): Promise<void> {
+  if (functionInitPromise) return functionInitPromise;
+
+  functionInitPromise = (async () => {
+    await Promise.all([
+      initFirebaseApp(),
+      initRedis(),
+    ]);
+    initDiscordRest(); // REST 토큰 주입(동기) — gateway WS/login 없음
+    globalLogger.info("Function providers initialized (REST only).");
+  })().catch((error) => {
+    functionInitPromise = null;
+    throw error;
+  });
+
+  return functionInitPromise;
+}
+
+/**
+ * 하위 호환 별칭 — 기존 import처(app/index.ts) 보호.
+ * gateway 번들과 동일하다.
+ */
+export const initializeProviders = initGatewayProviders;

--- a/functions/src/providers/redis/manager/redisManager.ts
+++ b/functions/src/providers/redis/manager/redisManager.ts
@@ -1,4 +1,5 @@
 import "@/common/utils/systemLogger";
+import crypto from "node:crypto";
 import { RedisClientType } from "redis";
 import { RecruitCacheStore, RecruitHashStore, CrawlCacheStore } from "../store";
 import { redisKeyManager } from "../key";
@@ -58,5 +59,24 @@ export class RedisManager {
       }
       return { newCursor: 0, foundKeys: [] };
     }
+  }
+
+  /**
+   * 분산 락 획득 (SET key token NX PX). 획득 성공 시 해제용 토큰 반환, 실패(이미 잠김) 시 null.
+   * @param key 락 키 (예: "lock:recruit:crawlAndDiff")
+   * @param ttlMs 락 자동 만료(ms) — 홀더 크래시 시 교착 방지
+   */
+  async acquireLock(key: string, ttlMs: number): Promise<string | null> {
+    const token = crypto.randomUUID();
+    const res = await this.client.set(key, token, { NX: true, PX: ttlMs });
+    return res === "OK" ? token : null;
+  }
+
+  /**
+   * 분산 락 해제 — 토큰이 일치할 때만 삭제(다른 홀더 락 오삭제 방지). CAS는 Lua로 원자 처리.
+   */
+  async releaseLock(key: string, token: string): Promise<void> {
+    const lua = `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`;
+    await this.client.eval(lua, { keys: [key], arguments: [token] });
   }
 };

--- a/functions/src/services/claude.md
+++ b/functions/src/services/claude.md
@@ -95,8 +95,8 @@ export class RecruitCacheService {
         Deleted: ${deletedIds.length}`);
 
       // ⭐ 이벤트 발행 추가
-      eventBus.emitEvent(EventType.RECRUIT_NEW, {
-        type: EventType.RECRUIT_NEW,
+      eventBus.emitEvent(EventType.RECRUIT_CHANGED, {
+        type: EventType.RECRUIT_CHANGED,
         timestamp: new Date(),
         source: 'RecruitCacheService',
         data: { addedJobs, updatedJobs, deletedIds }
@@ -156,7 +156,7 @@ export class RecruitCacheService {
 ### 구현
 ```typescript
 import { eventBus } from '@/eventBus/EventBus';
-import { EventType, RecruitNewEvent } from '@/eventBus/types';
+import { EventType, RecruitChangedEvent } from '@/eventBus/types';
 import { SubscriptionStore } from '@/providers/firebase/store/subscription';
 import { sendNotificationDM } from '@/providers/discord/utils/dmSender';
 import { filterByRegion } from '@/features/notification/filters/RecruitFilter';
@@ -165,8 +165,8 @@ export class NotificationService {
   private readonly subscriptionStore = new SubscriptionStore();
 
   constructor() {
-    // recruit.new 이벤트 리스너 등록
-    eventBus.onEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, (payload) => {
+    // recruit:changed 이벤트 리스너 등록
+    eventBus.onEvent<RecruitChangedEvent>(EventType.RECRUIT_CHANGED, (payload) => {
       this.notifyNewRecruits(payload.data);
     });
   }
@@ -403,7 +403,7 @@ export const aiService = new AIService();
 
 ### Phase 1.7 (notificationService)
 1. notificationService.ts 생성
-2. recruit.new 이벤트 리스너 등록
+2. recruit:changed 이벤트 리스너 등록
 3. 구독자 필터링 로직 구현
 4. DM 발송 조율
 

--- a/functions/src/services/notificationService.ts
+++ b/functions/src/services/notificationService.ts
@@ -1,13 +1,13 @@
 import "@/common/utils/systemLogger"; // globalLogger 전역 등록
 import { SubscriptionStore } from "@/providers/firebase/store/subscription";
 import { eventBus, EventType } from "@/events/bus";
-import type { RecruitNewEvent, NotificationSendEvent } from "@/events/bus";
+import type { RecruitChangedEvent, NotificationSendEvent } from "@/events/bus";
 import { filterByMode } from "@/common/utils/recruitFilter";
 
 /**
  * 자동 알림 오케스트레이션 서비스 (Phase 1.7)
  *
- * `RECRUIT_NEW` 수신 → 활성 구독자 조회 → 모드/지역 필터 → 구독자별
+ * `RECRUIT_CHANGED` 수신 → 활성 구독자 조회 → 모드/지역 필터 → 구독자별
  * `NOTIFICATION_SEND` 발행까지 담당한다.
  *
  * @remarks 설계 경계 = 이벤트 경계. 실제 DM 발송은 Phase 1.8 핸들러가
@@ -21,9 +21,9 @@ export class NotificationService {
    * 새 공고(추가 + 변경)를 활성 구독자별로 필터링하여
    * 매칭 공고가 1건 이상인 구독자에게 `NOTIFICATION_SEND`를 발행한다.
    *
-   * @param payload `RECRUIT_NEW` 이벤트 페이로드
+   * @param payload `RECRUIT_CHANGED` 이벤트 페이로드
    */
-  async notifyNewRecruits(payload: RecruitNewEvent): Promise<void> {
+  async notifyNewRecruits(payload: RecruitChangedEvent): Promise<void> {
     const targetJobs = [...payload.addedJobs, ...payload.updatedJobs];
     if (targetJobs.length === 0) return;
 
@@ -33,7 +33,8 @@ export class NotificationService {
       const matchedJobs = filterByMode(targetJobs, subscriber);
       if (matchedJobs.length === 0) continue;
 
-      eventBus.emitEvent<NotificationSendEvent>(EventType.NOTIFICATION_SEND, {
+      // 서버리스 tick이 DM 발송 완결까지 await하도록 emitEventAndSettle 사용.
+      await eventBus.emitEventAndSettle<NotificationSendEvent>(EventType.NOTIFICATION_SEND, {
         timestamp: Date.now(),
         source: "NotificationService",
         userId: subscriber.userId,

--- a/functions/src/services/recruitCacheService.ts
+++ b/functions/src/services/recruitCacheService.ts
@@ -3,8 +3,15 @@ import { RecruitCacheStore, RecruitHashStore } from "../providers/redis/store";
 import type { CityEn } from "@/common/types/city.d";
 import type { Job, HashedString, JobDiffResult, JobHashes } from "@/common/types/job.d";
 import type { RecruitData } from "@/crawlers/types";
-import { eventBus, EventType } from "@/events/bus";
-import type { RecruitNewEvent } from "@/events/bus";
+
+/**
+ * 공고 캐시 갱신 결과 상태
+ */
+export enum CacheUpdateStatus {
+  NO_DATA = "NO_DATA",
+  UNCHANGED = "UNCHANGED",
+  CHANGED = "CHANGED",
+}
 
 /**
  * 공고 리스트 갱신 흐름:
@@ -28,13 +35,9 @@ export class RecruitCacheService {
       : await this.cacheStore.getAll();
   }
 
-  async setRecruitList(list: RecruitData[]) {
-    enum CacheUpdateStatus {
-      NO_DATA = "NO_DATA",
-      UNCHANGED = "UNCHANGED",
-      CHANGED = "CHANGED"
-    };
-
+  async setRecruitList(
+    list: RecruitData[]
+  ): Promise<{ status: CacheUpdateStatus; diff: JobDiffResult }> {
     const expiration = 6 * 60 * 60;  // 6시간
     const newJobs = this.mapToJob(list);
     const newHashes = this.createHashes(newJobs);
@@ -62,43 +65,27 @@ export class RecruitCacheService {
     switch (status) {
       case CacheUpdateStatus.NO_DATA:
         await this.saveAll(newJobs, newHashes, expiration);
-        globalLogger.info("No data found. Data cached successfully and expiry of 6 hours.");
+        // NOTE: 기준선(currentHashes) 부재로 diff 비교가 불가능하여 RECRUIT_CHANGED 미발행은 의도된 동작
+        globalLogger.warn("No data found. Data cached successfully and expiry of 6 hours. (기준선 부재로 RECRUIT_CHANGED 미발행)");
         break;
 
-      case CacheUpdateStatus.CHANGED:
+      case CacheUpdateStatus.CHANGED: {
         const { addedJobs, updatedJobs, deletedIds } = diffJobs;
         await this.syncChanges(addedJobs, updatedJobs, deletedIds, newHashes, expiration);
         globalLogger.info(`
           Redis cache updated.\n
           added: ${addedJobs.length}, deleted: ${deletedIds.length}, updated: ${updatedJobs.length}
         `);
-
-        // 새 공고 발견 시 이벤트 발행
-        // NOTE: Job[] 전체 전달 (id + value)
-        // - Phase 1.7의 구독자가 필요시 Job.id 사용 가능
-        // - 페이로드 최소화(value만 추출) vs 타입 정의 변경의 이펙트를 고려하여 Job[] 유지
-        try {
-          eventBus.emitEvent<RecruitNewEvent>(EventType.RECRUIT_NEW, {
-            timestamp: Date.now(),
-            source: "RecruitCacheService",
-            addedJobs,
-            updatedJobs,
-            deletedIds,
-          });
-        } catch (error) {
-          globalLogger.error("이벤트 발행 실패", error as Error, {
-            event: EventType.RECRUIT_NEW,
-            source: "RecruitCacheService",
-          });
-          // 캐시 업데이트는 이미 성공했으므로 계속 진행
-        }
         break;
+      }
 
       case CacheUpdateStatus.UNCHANGED:
         await this.extendExpiration(expiration);
         globalLogger.info("No changes. Expiration extended.");
         break;
     }
+
+    return { status, diff: diffJobs };
   }
 
   private createHashes(jobs: Job[]): JobHashes {

--- a/functions/src/services/recruitService.ts
+++ b/functions/src/services/recruitService.ts
@@ -3,9 +3,12 @@ import { CRAWL_MODE } from "@/common/constants";
 import { RedisManager } from "../providers/redis/manager/redisManager";
 import { RecruitStore } from "../providers/firebase/store";
 import { RecruitCacheService, CrawlService } from "../services";
+import { CacheUpdateStatus } from "@/services/recruitCacheService";
 import { CityKo, CityEn } from "@/common/types";
 import type { RecruitData } from "@/crawlers/types";
 import type { RecruitTier } from "@/events/bus";
+import { emitRecruitChangedEvent } from "@/events/bus";
+import type { JobDiffResult } from "@/common/types/job.d";
 import { cityNameConverter } from "@/common/utils/cityName";
 import { getCityFilteredList } from "@/common/utils";
 import { HttpError } from "@/common/utils/httpError";
@@ -55,10 +58,16 @@ export class RecruitService {
     try {
       const firestoreData = await this.firestore.getRecruitList();
       if (firestoreData) {
-        // 캐시 백업 시도
-        this.cacheService.setRecruitList(firestoreData).catch(() => {
-          globalLogger.warn("캐시 저장 실패");
-        });
+        // 캐시 백업 시도 (CHANGED 시 RECRUIT_CHANGED 발행 — fire-and-forget)
+        this.cacheService.setRecruitList(firestoreData)
+          .then(({ status, diff }) => {
+            if (status === CacheUpdateStatus.CHANGED) {
+              void emitRecruitChangedEvent(diff, "RecruitService", { awaitSettle: false });
+            }
+          })
+          .catch(() => {
+            globalLogger.warn("캐시 저장 실패");
+          });
         return { data: await getCityFilteredList(mode, convertedCity, firestoreData), tier: "firestore", durationMs: Date.now() - startedAt };
       }
     } catch (err) {
@@ -81,6 +90,36 @@ export class RecruitService {
     return { data: await getCityFilteredList(mode, convertedCity, crawled), tier: "crawler", durationMs: Date.now() - startedAt };
   }
 
+  /**
+   * 스케줄러 전용 크롤→diff→(CHANGED시)RECRUIT_CHANGED 발행. getRecruitList 3-tier를 우회한다.
+   * Redis 분산 락으로 사용자 백업 write와의 hash 경합(중복 emit)을 방지.
+   * @param mode CRAWL_MODE (city 미지정 = 전체 지역 — 부분 스코프 결과를 diff에 넣지 않음)
+   */
+  async crawlAndDiff(mode: CRAWL_MODE): Promise<JobDiffResult> {
+    const empty: JobDiffResult = { addedJobs: [], updatedJobs: [], deletedIds: [] };
+    const LOCK_KEY = "lock:recruit:crawlAndDiff";
+    const redis = RedisManager.getInstance();
+    const token = await redis.acquireLock(LOCK_KEY, 60_000);
+    if (!token) {
+      globalLogger.warn("crawlAndDiff 락 획득 실패 — 다른 크롤 진행 중, 스킵");
+      return empty;
+    }
+    try {
+      const list = await this.crawler.sriagent(mode); // city 미지정 = 전체
+      if (!list || list.length === 0) {
+        globalLogger.warn("crawlAndDiff: 크롤 결과 없음 — setRecruitList 스킵(오삭제 방지)");
+        return empty;
+      }
+      const { status, diff } = await this.cacheService.setRecruitList(list);
+      if (status === CacheUpdateStatus.CHANGED) {
+        await emitRecruitChangedEvent(diff, "RecruitService.crawlAndDiff", { awaitSettle: true });
+      }
+      return diff;
+    } finally {
+      await redis.releaseLock(LOCK_KEY, token);
+    }
+  }
+
   private async collectAndSaveRecruits(mode: CRAWL_MODE, city?: CityKo): Promise<RecruitData[] | null> {
     const list = await this.crawler.sriagent(mode, city);
 
@@ -93,9 +132,15 @@ export class RecruitService {
       this.firestore.saveRecruitList(list).catch(() => {
         globalLogger.warn("Firestore 저장 실패");
       }),
-      this.cacheService.setRecruitList(list).catch(() => {
-        globalLogger.warn("Redis 저장 실패");
-      })
+      this.cacheService.setRecruitList(list)
+        .then(({ status, diff }) => {
+          if (status === CacheUpdateStatus.CHANGED) {
+            void emitRecruitChangedEvent(diff, "RecruitService", { awaitSettle: false });
+          }
+        })
+        .catch(() => {
+          globalLogger.warn("Redis 저장 실패");
+        })
     ]);
 
     return list;


### PR DESCRIPTION
## Summary
C안 하이브리드 런타임 분리 — 인터랙션 수신용 **Gateway 프로세스(상시)** 와 크롤·알림용 **Function 프로세스(serverless onSchedule)** 를 분리했습니다. 범위는 **코드 + 정적/로컬 검증 한정**이며, 실배포·실 CRAWL·프로덕션 E2E는 Phase 1.10으로 이월합니다.

## 주요 변경사항
- **진입점 분리**: `initGatewayProviders` / `initFunctionProviders` + `app/scheduler.ts` 신규
- **트리거 전환**: setTimeout 루프 → `onSchedule("every 4 hours")` + `BaseScheduler.runOnce()` 단일 tick 추출
- **DM 전송 REST 전환**: `dmSender` gateway 로그인 의존 제거 → 2-step REST(`initDiscordRest`). `DmPayload`/`DmSendResult` 계약 불변
- **틱 완결 파이프라인**: `emitEventAndSettle` (additive) — `crawlAndDiff → RECRUIT_CHANGED → NOTIFICATION_SEND` await 전파
- **크롤 경로 재설계**: `crawlAndDiff` 신설(3-tier 우회 강제 크롤) + Redis 분산 락(`SET NX PX` + Lua CAS)
- **이벤트 리네임**: `RECRUIT_NEW` → `RECRUIT_CHANGED` (add/update/delete 변경 감지 의미로 정정)

## 기술적 개선사항
- 서버리스 tick이 DM 발송 완결까지 await → in-flight 알림 유실 방지
- 동시 크롤 중복·중복 알림 방지 (분산 락, TTL 60s)
- `runOnce()` 단일 tick 분리로 로컬 검증/onSchedule/테스트가 동일 로직 공유

## 테스트 상태
- 정적: `npx tsc --noEmit` **exit 0**
- 로컬 DUMMY 런타임 검증(review-process 0단계):
  - R1 slim 부트(REST 전용, gateway 로그인 없음) ✅
  - R2 DUMMY tick 완주(crawl→diff→발화 직전, 실 DM 0) ✅
  - R3 Redis 분산 락(정상 획득·해제 / 경합 시 스킵) ✅
  - diff 3케이스(add/update/delete) 발행 검증 ✅
- R4(실 DM 전송)·R5(실배포 트리거)는 Phase 1.10 사용자 검증 이월

## Breaking Changes
- 없음 — `dmSender` 시그니처/계약, `getRecruitList` 3-tier, 인터랙션 수신 코드 모두 불변. 이벤트 리네임은 로컬 전용이라 외부 호환 영향 없음.

Ref: pdca-status.json Phase 1.13